### PR TITLE
feat: add default catalog to container image

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -26,6 +26,8 @@ RUN CGO_ENABLED=1 GOOS=linux GOEXPERIMENT=strictfipsruntime go build -tags stric
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:8d905a93f1392d4a8f7fb906bd49bf540290674b28d82de3536bb4d0898bf9d7
  
 WORKDIR /
+
+COPY manifests/kustomize/options/catalog/default-catalog.yaml /default-catalog.yaml
  
 COPY --from=builder /workspace/model-registry .
  


### PR DESCRIPTION
## Description
Adds `/default-catalog.yaml` to the image for the operator's default sources file to reference.

## How Has This Been Tested?
Built the image and verified that the file exists.

## Merge criteria:

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
