### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-model-registry-v2-22

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -39,7 +39,8 @@ EXPOSE 8080
 CMD /model-registry proxy -logtostderr=true
  
 LABEL com.redhat.component="odh-model-registry-container" \
-      name="managed-open-data-hub/odh-model-registry-rhel8" \
+      name="rhoai/odh-model-registry-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.22::el9" \
       description="Container that provides a central repository for model developers to store and manage models, versions, and artifacts metadata." \
       summary="odh-model-registry" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
