### PR TITLE
chore(deps): refresh RPM lockfiles for rhoai-2.25

### DIFF
--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -39,13 +39,13 @@ arches:
         name: criu-libs
         evr: 3.19-3.el9
         sourcerpm: criu-3.19-3.el9.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/crun-1.23.1-2.el9_7.aarch64.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/crun-1.27-1.el9_7.aarch64.rpm
         repoid: ubi-9-for-aarch64-appstream-rpms
-        size: 234324
-        checksum: sha256:662139a1c439d3b89c60de59cef5ca1d11b0a9e31f4abbb2981ddf91bb77e88f
+        size: 251685
+        checksum: sha256:bbc7e023c9ffa117101ca68007ce72512ccde579ccaf06e5589f3b0139ebdf19
         name: crun
-        evr: 1.23.1-2.el9_7
-        sourcerpm: crun-1.23.1-2.el9_7.src.rpm
+        evr: 1.27-1.el9_7
+        sourcerpm: crun-1.27-1.el9_7.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fuse-overlayfs-1.16-1.el9_7.aarch64.rpm
         repoid: ubi-9-for-aarch64-appstream-rpms
         size: 63393
@@ -88,13 +88,13 @@ arches:
         name: glibc-devel
         evr: 2.34-231.el9_7.10
         sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-611.36.1.el9_7.aarch64.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-611.47.1.el9_7.aarch64.rpm
         repoid: ubi-9-for-aarch64-appstream-rpms
-        size: 2980805
-        checksum: sha256:cbe473056fc3545d70925d1c6ff9fbd3a6b4f5ef83b4071546ef74186ee93777
+        size: 2986913
+        checksum: sha256:f768b38bcf574477b6b0fd6a621948447cb8f5aa4e3cf7392cc1a272e794049c
         name: kernel-headers
-        evr: 5.14.0-611.36.1.el9_7
-        sourcerpm: kernel-5.14.0-611.36.1.el9_7.src.rpm
+        evr: 5.14.0-611.47.1.el9_7
+        sourcerpm: kernel-5.14.0-611.47.1.el9_7.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libasan-11.5.0-11.el9.aarch64.rpm
         repoid: ubi-9-for-aarch64-appstream-rpms
         size: 408716
@@ -172,27 +172,27 @@ arches:
         name: mpdecimal
         evr: 2.5.1-3.el9
         sourcerpm: mpdecimal-2.5.1-3.el9.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.aarch64.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.2.aarch64.rpm
         repoid: ubi-9-for-aarch64-appstream-rpms
-        size: 32476
-        checksum: sha256:2a637766bc065924225506b46f2c7592e25c9f6b76b6d202b900f3c8c2037ffc
+        size: 32669
+        checksum: sha256:e4b898a306c9199feb6d72ec8f3c6fb6736e339a9a9e787a19732decb9c2c4c6
         name: python3.12
-        evr: 3.12.12-4.el9_7
-        sourcerpm: python3.12-3.12.12-4.el9_7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-devel-3.12.12-4.el9_7.aarch64.rpm
+        evr: 3.12.12-4.el9_7.2
+        sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-devel-3.12.12-4.el9_7.2.aarch64.rpm
         repoid: ubi-9-for-aarch64-appstream-rpms
-        size: 338253
-        checksum: sha256:7eca214d3fc1d3e9c5fbdecb0ae44306a6af73c106cbc431462740fb0f9fdd80
+        size: 338397
+        checksum: sha256:4481087f395c732dd7341452cc567af37bcafec1f803bdf9a81389b367c7fdd1
         name: python3.12-devel
-        evr: 3.12.12-4.el9_7
-        sourcerpm: python3.12-3.12.12-4.el9_7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.aarch64.rpm
+        evr: 3.12.12-4.el9_7.2
+        sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.2.aarch64.rpm
         repoid: ubi-9-for-aarch64-appstream-rpms
-        size: 10135295
-        checksum: sha256:5f9e311357920e8f0948ab0f48b2c0fa26986d968709b66408106cdd63856e6a
+        size: 10140707
+        checksum: sha256:6cc853fb09b9b81fe4da67619cd8b879e2ccfd9d16f617e597cb0759e62fbb0c
         name: python3.12-libs
-        evr: 3.12.12-4.el9_7
-        sourcerpm: python3.12-3.12.12-4.el9_7.src.rpm
+        evr: 3.12.12-4.el9_7.2
+        sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
         repoid: ubi-9-for-aarch64-appstream-rpms
         size: 1527128
@@ -487,27 +487,27 @@ arches:
         name: shadow-utils-subid
         evr: 2:4.9-15.el9
         sourcerpm: shadow-utils-4.9-15.el9.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-252-55.el9_7.7.aarch64.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-252-55.el9_7.8.aarch64.rpm
         repoid: ubi-9-for-aarch64-baseos-rpms
-        size: 4164980
-        checksum: sha256:0e4586403987336152fb2a41a5a34c1c2cefd113a771aa3c4892ff0ab2884213
+        size: 4147103
+        checksum: sha256:348395d1ccc05115d945d7cff55c13bcb0ee6bfc00cf7fd61f8df52589dbbeab
         name: systemd
-        evr: 252-55.el9_7.7
-        sourcerpm: systemd-252-55.el9_7.7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-pam-252-55.el9_7.7.aarch64.rpm
+        evr: 252-55.el9_7.8
+        sourcerpm: systemd-252-55.el9_7.8.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-pam-252-55.el9_7.8.aarch64.rpm
         repoid: ubi-9-for-aarch64-baseos-rpms
-        size: 278843
-        checksum: sha256:070626cdc2574c6897a5b3417e1426a2227f9a852b5d6de4a3da718f8183a457
+        size: 263658
+        checksum: sha256:6e6361fc960761e02f73f8c88fd7682461f55aec25fa1ee75277f1445ed13876
         name: systemd-pam
-        evr: 252-55.el9_7.7
-        sourcerpm: systemd-252-55.el9_7.7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-rpm-macros-252-55.el9_7.7.noarch.rpm
+        evr: 252-55.el9_7.8
+        sourcerpm: systemd-252-55.el9_7.8.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-rpm-macros-252-55.el9_7.8.noarch.rpm
         repoid: ubi-9-for-aarch64-baseos-rpms
-        size: 72275
-        checksum: sha256:dd54f47d3773db296cdff65dbc1fc423416a7d1bed7447a11c715a2017ae8760
+        size: 57061
+        checksum: sha256:807a9519d7a3f6b2168ca47666b43e1630b3fa82256e919633a07baa5906b1b2
         name: systemd-rpm-macros
-        evr: 252-55.el9_7.7
-        sourcerpm: systemd-252-55.el9_7.7.src.rpm
+        evr: 252-55.el9_7.8
+        sourcerpm: systemd-252-55.el9_7.8.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tar-1.34-9.el9_7.aarch64.rpm
         repoid: ubi-9-for-aarch64-baseos-rpms
         size: 898317
@@ -542,12 +542,12 @@ arches:
         checksum: sha256:935cde45890eee106b48c5a17fcce9a359bbc33e5867c7433012a28fdc095e90
         name: criu
         evr: 3.19-3.el9
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/c/crun-1.23.1-2.el9_7.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/c/crun-1.27-1.el9_7.src.rpm
         repoid: ubi-9-for-aarch64-appstream-source-rpms
-        size: 845412
-        checksum: sha256:19500c02ad50c34f29a7c69d69fb48a7675c9915a0656c272b82ccbf93bd32bd
+        size: 908477
+        checksum: sha256:0b6d37252bb27dedbc9770b7f968e1b903d8d8a2f0fa4cc0d6d201cb1a00d189
         name: crun
-        evr: 1.23.1-2.el9_7
+        evr: 1.27-1.el9_7
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.16-1.el9_7.src.rpm
         repoid: ubi-9-for-aarch64-appstream-source-rpms
         size: 127644
@@ -590,12 +590,12 @@ arches:
         checksum: sha256:2f5ece89d6a8d892816f386462d8be291ad83f1500b4c4b3655dcc7ed5192c0d
         name: mpdecimal
         evr: 2.5.1-3.el9
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.2.src.rpm
         repoid: ubi-9-for-aarch64-appstream-source-rpms
-        size: 20873997
-        checksum: sha256:1f4a8ae3002de2a536e58c42ec410bcd9cf3371c40b3b3d8efb2c58feece28f7
+        size: 20880557
+        checksum: sha256:0d4494e18c3a6b5c62c96ef5786561fc6fab96cd50f2380c1471d2eaeabd06fd
         name: python3.12
-        evr: 3.12.12-4.el9_7
+        evr: 3.12.12-4.el9_7.2
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/p/python3.12-pip-23.2.1-5.el9.src.rpm
         repoid: ubi-9-for-aarch64-appstream-source-rpms
         size: 9384965
@@ -788,12 +788,12 @@ arches:
         checksum: sha256:c6feefc65a20ec4203979e0cde4d4a6d86981ac7c836e55148273bd9fc2b57b2
         name: shadow-utils
         evr: 2:4.9-15.el9
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/s/systemd-252-55.el9_7.7.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/s/systemd-252-55.el9_7.8.src.rpm
         repoid: ubi-9-for-aarch64-baseos-source-rpms
-        size: 44902530
-        checksum: sha256:c3ec3a6af5ab03b57450f24d12297eaf66191292c699cec4f52ee47688159d9c
+        size: 44888096
+        checksum: sha256:a633587c7170f5928a0bf1ba144f8f58d759cfdcbc4e6437c4dcb74b1742c69b
         name: systemd
-        evr: 252-55.el9_7.7
+        evr: 252-55.el9_7.8
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/t/tar-1.34-9.el9_7.src.rpm
         repoid: ubi-9-for-aarch64-baseos-source-rpms
         size: 2282680
@@ -844,13 +844,13 @@ arches:
         name: criu-libs
         evr: 3.19-3.el9
         sourcerpm: criu-3.19-3.el9.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/crun-1.23.1-2.el9_7.ppc64le.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/crun-1.27-1.el9_7.ppc64le.rpm
         repoid: ubi-9-for-ppc64le-appstream-rpms
-        size: 272818
-        checksum: sha256:d0d0594fa30609113c32f761424b5a043af18074871dbfcded7480a4aca03b42
+        size: 292730
+        checksum: sha256:74138a8a9d80a6f5f5034c3de5a00a9236703426c5f6584befd8a40395e47e51
         name: crun
-        evr: 1.23.1-2.el9_7
-        sourcerpm: crun-1.23.1-2.el9_7.src.rpm
+        evr: 1.27-1.el9_7
+        sourcerpm: crun-1.27-1.el9_7.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/f/fuse-overlayfs-1.16-1.el9_7.ppc64le.rpm
         repoid: ubi-9-for-ppc64le-appstream-rpms
         size: 69175
@@ -893,13 +893,13 @@ arches:
         name: glibc-devel
         evr: 2.34-231.el9_7.10
         sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-611.36.1.el9_7.ppc64le.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-611.47.1.el9_7.ppc64le.rpm
         repoid: ubi-9-for-ppc64le-appstream-rpms
-        size: 3002489
-        checksum: sha256:79d78d1b16c5ba59060c2d72a03c0f3d1025530970476504f5710c85ddade716
+        size: 3008577
+        checksum: sha256:7eb6ce67e2ba48169392a4518c6941eeae855563070d07f6eaa831cf80606a74
         name: kernel-headers
-        evr: 5.14.0-611.36.1.el9_7
-        sourcerpm: kernel-5.14.0-611.36.1.el9_7.src.rpm
+        evr: 5.14.0-611.47.1.el9_7
+        sourcerpm: kernel-5.14.0-611.47.1.el9_7.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libasan-11.5.0-11.el9.ppc64le.rpm
         repoid: ubi-9-for-ppc64le-appstream-rpms
         size: 440457
@@ -977,27 +977,27 @@ arches:
         name: mpdecimal
         evr: 2.5.1-3.el9
         sourcerpm: mpdecimal-2.5.1-3.el9.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.ppc64le.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.2.ppc64le.rpm
         repoid: ubi-9-for-ppc64le-appstream-rpms
-        size: 32521
-        checksum: sha256:e1a2c681b60c55f97099fd21e3888f1fc5c5cb64a2b4f7ab4f57d72c336c2d8b
+        size: 32721
+        checksum: sha256:df48b88f619974806aa26e56218b32e86b1996718c9e1dfd9ca1d9a77d039ec3
         name: python3.12
-        evr: 3.12.12-4.el9_7
-        sourcerpm: python3.12-3.12.12-4.el9_7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-devel-3.12.12-4.el9_7.ppc64le.rpm
+        evr: 3.12.12-4.el9_7.2
+        sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-devel-3.12.12-4.el9_7.2.ppc64le.rpm
         repoid: ubi-9-for-ppc64le-appstream-rpms
-        size: 338374
-        checksum: sha256:522b6deb594f6fafa10e370f3f432adf3c2f92473f5a825ce51685925c3028b5
+        size: 338575
+        checksum: sha256:aa58e69e6732f7c21a11717f8d56d1bca93d5e88fffb0f0b05c7de86778f6a48
         name: python3.12-devel
-        evr: 3.12.12-4.el9_7
-        sourcerpm: python3.12-3.12.12-4.el9_7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.ppc64le.rpm
+        evr: 3.12.12-4.el9_7.2
+        sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.2.ppc64le.rpm
         repoid: ubi-9-for-ppc64le-appstream-rpms
-        size: 10080493
-        checksum: sha256:d6246597c8d95668deac35cd2700c929e5a67ef12b3e8b8175b858ed56f2dbc3
+        size: 10083489
+        checksum: sha256:b9b9d3119c30def6fb374bc43594af52bd0ab6cb54465d83f10b8f73fc9563d0
         name: python3.12-libs
-        evr: 3.12.12-4.el9_7
-        sourcerpm: python3.12-3.12.12-4.el9_7.src.rpm
+        evr: 3.12.12-4.el9_7.2
+        sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
         repoid: ubi-9-for-ppc64le-appstream-rpms
         size: 1527128
@@ -1299,27 +1299,27 @@ arches:
         name: shadow-utils-subid
         evr: 2:4.9-15.el9
         sourcerpm: shadow-utils-4.9-15.el9.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/systemd-252-55.el9_7.7.ppc64le.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/systemd-252-55.el9_7.8.ppc64le.rpm
         repoid: ubi-9-for-ppc64le-baseos-rpms
-        size: 4444738
-        checksum: sha256:1fda3330e62c7f2b5be7326201a2ad90ab36c09a3acec73b9a7627b84c2b99e7
+        size: 4429959
+        checksum: sha256:cd0eddb43f73a2b75c059aae679e400c1c906be503dd989ee2ec415b82db7366
         name: systemd
-        evr: 252-55.el9_7.7
-        sourcerpm: systemd-252-55.el9_7.7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/systemd-pam-252-55.el9_7.7.ppc64le.rpm
+        evr: 252-55.el9_7.8
+        sourcerpm: systemd-252-55.el9_7.8.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/systemd-pam-252-55.el9_7.8.ppc64le.rpm
         repoid: ubi-9-for-ppc64le-baseos-rpms
-        size: 307132
-        checksum: sha256:cf8ab8808c43fb65312f8b3399853c89d3792c4bd38ed46cb323bb738d93962b
+        size: 291947
+        checksum: sha256:3ff940b11e05c11b1be415c6e5444bf365ab5516dde717ef5f49c32ebbdf4ed6
         name: systemd-pam
-        evr: 252-55.el9_7.7
-        sourcerpm: systemd-252-55.el9_7.7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/systemd-rpm-macros-252-55.el9_7.7.noarch.rpm
+        evr: 252-55.el9_7.8
+        sourcerpm: systemd-252-55.el9_7.8.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/s/systemd-rpm-macros-252-55.el9_7.8.noarch.rpm
         repoid: ubi-9-for-ppc64le-baseos-rpms
-        size: 72275
-        checksum: sha256:dd54f47d3773db296cdff65dbc1fc423416a7d1bed7447a11c715a2017ae8760
+        size: 57061
+        checksum: sha256:807a9519d7a3f6b2168ca47666b43e1630b3fa82256e919633a07baa5906b1b2
         name: systemd-rpm-macros
-        evr: 252-55.el9_7.7
-        sourcerpm: systemd-252-55.el9_7.7.src.rpm
+        evr: 252-55.el9_7.8
+        sourcerpm: systemd-252-55.el9_7.8.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/t/tar-1.34-9.el9_7.ppc64le.rpm
         repoid: ubi-9-for-ppc64le-baseos-rpms
         size: 938310
@@ -1354,12 +1354,12 @@ arches:
         checksum: sha256:935cde45890eee106b48c5a17fcce9a359bbc33e5867c7433012a28fdc095e90
         name: criu
         evr: 3.19-3.el9
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/c/crun-1.23.1-2.el9_7.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/c/crun-1.27-1.el9_7.src.rpm
         repoid: ubi-9-for-ppc64le-appstream-source-rpms
-        size: 845412
-        checksum: sha256:19500c02ad50c34f29a7c69d69fb48a7675c9915a0656c272b82ccbf93bd32bd
+        size: 908477
+        checksum: sha256:0b6d37252bb27dedbc9770b7f968e1b903d8d8a2f0fa4cc0d6d201cb1a00d189
         name: crun
-        evr: 1.23.1-2.el9_7
+        evr: 1.27-1.el9_7
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.16-1.el9_7.src.rpm
         repoid: ubi-9-for-ppc64le-appstream-source-rpms
         size: 127644
@@ -1402,12 +1402,12 @@ arches:
         checksum: sha256:2f5ece89d6a8d892816f386462d8be291ad83f1500b4c4b3655dcc7ed5192c0d
         name: mpdecimal
         evr: 2.5.1-3.el9
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.2.src.rpm
         repoid: ubi-9-for-ppc64le-appstream-source-rpms
-        size: 20873997
-        checksum: sha256:1f4a8ae3002de2a536e58c42ec410bcd9cf3371c40b3b3d8efb2c58feece28f7
+        size: 20880557
+        checksum: sha256:0d4494e18c3a6b5c62c96ef5786561fc6fab96cd50f2380c1471d2eaeabd06fd
         name: python3.12
-        evr: 3.12.12-4.el9_7
+        evr: 3.12.12-4.el9_7.2
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/p/python3.12-pip-23.2.1-5.el9.src.rpm
         repoid: ubi-9-for-ppc64le-appstream-source-rpms
         size: 9384965
@@ -1606,12 +1606,12 @@ arches:
         checksum: sha256:c6feefc65a20ec4203979e0cde4d4a6d86981ac7c836e55148273bd9fc2b57b2
         name: shadow-utils
         evr: 2:4.9-15.el9
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/s/systemd-252-55.el9_7.7.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/s/systemd-252-55.el9_7.8.src.rpm
         repoid: ubi-9-for-ppc64le-baseos-source-rpms
-        size: 44902530
-        checksum: sha256:c3ec3a6af5ab03b57450f24d12297eaf66191292c699cec4f52ee47688159d9c
+        size: 44888096
+        checksum: sha256:a633587c7170f5928a0bf1ba144f8f58d759cfdcbc4e6437c4dcb74b1742c69b
         name: systemd
-        evr: 252-55.el9_7.7
+        evr: 252-55.el9_7.8
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/t/tar-1.34-9.el9_7.src.rpm
         repoid: ubi-9-for-ppc64le-baseos-source-rpms
         size: 2282680
@@ -1662,13 +1662,13 @@ arches:
         name: criu-libs
         evr: 3.19-3.el9
         sourcerpm: criu-3.19-3.el9.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/crun-1.23.1-2.el9_7.s390x.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/crun-1.27-1.el9_7.s390x.rpm
         repoid: ubi-9-for-s390x-appstream-rpms
-        size: 231726
-        checksum: sha256:69b4f518b7f33e10a5423fad318e21d4372111f3a76502e6f7b47a2e9e80320b
+        size: 248910
+        checksum: sha256:d599e3dcb72ebaedf68e647c15415e7640524dc96424c481bd0e4702d69430c0
         name: crun
-        evr: 1.23.1-2.el9_7
-        sourcerpm: crun-1.23.1-2.el9_7.src.rpm
+        evr: 1.27-1.el9_7
+        sourcerpm: crun-1.27-1.el9_7.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/f/fuse-overlayfs-1.16-1.el9_7.s390x.rpm
         repoid: ubi-9-for-s390x-appstream-rpms
         size: 63890
@@ -1718,13 +1718,13 @@ arches:
         name: glibc-headers
         evr: 2.34-231.el9_7.10
         sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-611.36.1.el9_7.s390x.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-611.47.1.el9_7.s390x.rpm
         repoid: ubi-9-for-s390x-appstream-rpms
-        size: 3011041
-        checksum: sha256:59c07f180d83ca051b69717166fd4a8fe1562566b7f970d0f6707f4826614b64
+        size: 3017165
+        checksum: sha256:bccf67fd38fb285adc59ba6a0f0427553e39b917b699258cb8a7da8c7ca2a6dd
         name: kernel-headers
-        evr: 5.14.0-611.36.1.el9_7
-        sourcerpm: kernel-5.14.0-611.36.1.el9_7.src.rpm
+        evr: 5.14.0-611.47.1.el9_7
+        sourcerpm: kernel-5.14.0-611.47.1.el9_7.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libasan-11.5.0-11.el9.s390x.rpm
         repoid: ubi-9-for-s390x-appstream-rpms
         size: 412655
@@ -1802,27 +1802,27 @@ arches:
         name: mpdecimal
         evr: 2.5.1-3.el9
         sourcerpm: mpdecimal-2.5.1-3.el9.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.s390x.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.2.s390x.rpm
         repoid: ubi-9-for-s390x-appstream-rpms
-        size: 32329
-        checksum: sha256:8346d34504fcc8c9733af21b35994e7e83c41dbe88215665f22fb177b3001628
+        size: 32522
+        checksum: sha256:119db15b5df8df92bed4dd15c26d5d04cdf8e1d36dfebf732165818c6742751b
         name: python3.12
-        evr: 3.12.12-4.el9_7
-        sourcerpm: python3.12-3.12.12-4.el9_7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3.12-devel-3.12.12-4.el9_7.s390x.rpm
+        evr: 3.12.12-4.el9_7.2
+        sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3.12-devel-3.12.12-4.el9_7.2.s390x.rpm
         repoid: ubi-9-for-s390x-appstream-rpms
-        size: 338276
-        checksum: sha256:941477615c5558c2f3659369c77b8def7b1343593b4155a269254960c17c6216
+        size: 338369
+        checksum: sha256:7fb9a893a5b42fd05e63955ab69d04c60f6700befced70b2979efe98aea595e1
         name: python3.12-devel
-        evr: 3.12.12-4.el9_7
-        sourcerpm: python3.12-3.12.12-4.el9_7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.s390x.rpm
+        evr: 3.12.12-4.el9_7.2
+        sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.2.s390x.rpm
         repoid: ubi-9-for-s390x-appstream-rpms
-        size: 9972955
-        checksum: sha256:5af59a832c6c3c12e29fc861bbe30c6cb4f1dba50d09bcc035bd57361676b8a8
+        size: 9960665
+        checksum: sha256:01d5e75e5d85f769c03d24e9a80456b0330f3f8c9353115cd8364a482043d041
         name: python3.12-libs
-        evr: 3.12.12-4.el9_7
-        sourcerpm: python3.12-3.12.12-4.el9_7.src.rpm
+        evr: 3.12.12-4.el9_7.2
+        sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
         repoid: ubi-9-for-s390x-appstream-rpms
         size: 1527128
@@ -2117,27 +2117,27 @@ arches:
         name: shadow-utils-subid
         evr: 2:4.9-15.el9
         sourcerpm: shadow-utils-4.9-15.el9.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/s/systemd-252-55.el9_7.7.s390x.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/s/systemd-252-55.el9_7.8.s390x.rpm
         repoid: ubi-9-for-s390x-baseos-rpms
-        size: 4173009
-        checksum: sha256:22791ac0604ea333179cd6feadb9100acc8e5899df970717149930936c7d0952
+        size: 4159067
+        checksum: sha256:de7111736b8573fcf66535b0fd314ea072a3e3ec8496ff19d64ed91bce8bdb8b
         name: systemd
-        evr: 252-55.el9_7.7
-        sourcerpm: systemd-252-55.el9_7.7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/s/systemd-pam-252-55.el9_7.7.s390x.rpm
+        evr: 252-55.el9_7.8
+        sourcerpm: systemd-252-55.el9_7.8.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/s/systemd-pam-252-55.el9_7.8.s390x.rpm
         repoid: ubi-9-for-s390x-baseos-rpms
-        size: 278769
-        checksum: sha256:1195529d43e82ecd8790fffd09e2574a4c0be7826396866b85909d2f33e340e5
+        size: 263546
+        checksum: sha256:2edc22c93883c9e5dd9da2936005db8fe1bad378ab42f22d55977d7fe6e20cb4
         name: systemd-pam
-        evr: 252-55.el9_7.7
-        sourcerpm: systemd-252-55.el9_7.7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/s/systemd-rpm-macros-252-55.el9_7.7.noarch.rpm
+        evr: 252-55.el9_7.8
+        sourcerpm: systemd-252-55.el9_7.8.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/s/systemd-rpm-macros-252-55.el9_7.8.noarch.rpm
         repoid: ubi-9-for-s390x-baseos-rpms
-        size: 72275
-        checksum: sha256:dd54f47d3773db296cdff65dbc1fc423416a7d1bed7447a11c715a2017ae8760
+        size: 57061
+        checksum: sha256:807a9519d7a3f6b2168ca47666b43e1630b3fa82256e919633a07baa5906b1b2
         name: systemd-rpm-macros
-        evr: 252-55.el9_7.7
-        sourcerpm: systemd-252-55.el9_7.7.src.rpm
+        evr: 252-55.el9_7.8
+        sourcerpm: systemd-252-55.el9_7.8.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/t/tar-1.34-9.el9_7.s390x.rpm
         repoid: ubi-9-for-s390x-baseos-rpms
         size: 900131
@@ -2172,12 +2172,12 @@ arches:
         checksum: sha256:935cde45890eee106b48c5a17fcce9a359bbc33e5867c7433012a28fdc095e90
         name: criu
         evr: 3.19-3.el9
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/c/crun-1.23.1-2.el9_7.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/c/crun-1.27-1.el9_7.src.rpm
         repoid: ubi-9-for-s390x-appstream-source-rpms
-        size: 845412
-        checksum: sha256:19500c02ad50c34f29a7c69d69fb48a7675c9915a0656c272b82ccbf93bd32bd
+        size: 908477
+        checksum: sha256:0b6d37252bb27dedbc9770b7f968e1b903d8d8a2f0fa4cc0d6d201cb1a00d189
         name: crun
-        evr: 1.23.1-2.el9_7
+        evr: 1.27-1.el9_7
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.16-1.el9_7.src.rpm
         repoid: ubi-9-for-s390x-appstream-source-rpms
         size: 127644
@@ -2220,12 +2220,12 @@ arches:
         checksum: sha256:2f5ece89d6a8d892816f386462d8be291ad83f1500b4c4b3655dcc7ed5192c0d
         name: mpdecimal
         evr: 2.5.1-3.el9
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.2.src.rpm
         repoid: ubi-9-for-s390x-appstream-source-rpms
-        size: 20873997
-        checksum: sha256:1f4a8ae3002de2a536e58c42ec410bcd9cf3371c40b3b3d8efb2c58feece28f7
+        size: 20880557
+        checksum: sha256:0d4494e18c3a6b5c62c96ef5786561fc6fab96cd50f2380c1471d2eaeabd06fd
         name: python3.12
-        evr: 3.12.12-4.el9_7
+        evr: 3.12.12-4.el9_7.2
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/python3.12-pip-23.2.1-5.el9.src.rpm
         repoid: ubi-9-for-s390x-appstream-source-rpms
         size: 9384965
@@ -2418,12 +2418,12 @@ arches:
         checksum: sha256:c6feefc65a20ec4203979e0cde4d4a6d86981ac7c836e55148273bd9fc2b57b2
         name: shadow-utils
         evr: 2:4.9-15.el9
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/s/systemd-252-55.el9_7.7.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/s/systemd-252-55.el9_7.8.src.rpm
         repoid: ubi-9-for-s390x-baseos-source-rpms
-        size: 44902530
-        checksum: sha256:c3ec3a6af5ab03b57450f24d12297eaf66191292c699cec4f52ee47688159d9c
+        size: 44888096
+        checksum: sha256:a633587c7170f5928a0bf1ba144f8f58d759cfdcbc4e6437c4dcb74b1742c69b
         name: systemd
-        evr: 252-55.el9_7.7
+        evr: 252-55.el9_7.8
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/t/tar-1.34-9.el9_7.src.rpm
         repoid: ubi-9-for-s390x-baseos-source-rpms
         size: 2282680
@@ -2474,13 +2474,13 @@ arches:
         name: criu-libs
         evr: 3.19-3.el9
         sourcerpm: criu-3.19-3.el9.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/crun-1.23.1-2.el9_7.x86_64.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/crun-1.27-1.el9_7.x86_64.rpm
         repoid: ubi-9-for-x86_64-appstream-rpms
-        size: 249345
-        checksum: sha256:95eda856e7b59f6477a7ab8697182ad3f1d55f6169810e76987fc7cf787299f8
+        size: 268352
+        checksum: sha256:61b1d11863da6f3c0854fe7d83e97fb32e76569c64eaa413b6146b22beacf49a
         name: crun
-        evr: 1.23.1-2.el9_7
-        sourcerpm: crun-1.23.1-2.el9_7.src.rpm
+        evr: 1.27-1.el9_7
+        sourcerpm: crun-1.27-1.el9_7.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fuse-overlayfs-1.16-1.el9_7.x86_64.rpm
         repoid: ubi-9-for-x86_64-appstream-rpms
         size: 67299
@@ -2530,13 +2530,13 @@ arches:
         name: glibc-headers
         evr: 2.34-231.el9_7.10
         sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-611.36.1.el9_7.x86_64.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-611.47.1.el9_7.x86_64.rpm
         repoid: ubi-9-for-x86_64-appstream-rpms
-        size: 3019841
-        checksum: sha256:a8d6bc21a121506d3ab4557de140b256424fef20cb3e40fb411f21f55cee3544
+        size: 3025981
+        checksum: sha256:551f1d5cb5981a364fd119aaeacaad54e69c886308a7aaba3b4fa2e507b58d5d
         name: kernel-headers
-        evr: 5.14.0-611.36.1.el9_7
-        sourcerpm: kernel-5.14.0-611.36.1.el9_7.src.rpm
+        evr: 5.14.0-611.47.1.el9_7
+        sourcerpm: kernel-5.14.0-611.47.1.el9_7.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
         repoid: ubi-9-for-x86_64-appstream-rpms
         size: 66075
@@ -2600,27 +2600,27 @@ arches:
         name: mpdecimal
         evr: 2.5.1-3.el9
         sourcerpm: mpdecimal-2.5.1-3.el9.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.x86_64.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.2.x86_64.rpm
         repoid: ubi-9-for-x86_64-appstream-rpms
-        size: 32501
-        checksum: sha256:b8f6891103491d23b53ed7dc01319ce943a426194bddb47383ed8b05da7340c3
+        size: 32706
+        checksum: sha256:37b577f725f5ccc863f6d651585954153754e7e6bcbe9058d80f9d6e70f7c439
         name: python3.12
-        evr: 3.12.12-4.el9_7
-        sourcerpm: python3.12-3.12.12-4.el9_7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-devel-3.12.12-4.el9_7.x86_64.rpm
+        evr: 3.12.12-4.el9_7.2
+        sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-devel-3.12.12-4.el9_7.2.x86_64.rpm
         repoid: ubi-9-for-x86_64-appstream-rpms
-        size: 338363
-        checksum: sha256:3b278827df7abf18464b8100a19ecd5d94971a71f528803522ff3de43fa17f1e
+        size: 338609
+        checksum: sha256:3ae0df091c090782f4f26cc532835ca86c73d308afb40b78c8cf7191b7c4dad5
         name: python3.12-devel
-        evr: 3.12.12-4.el9_7
-        sourcerpm: python3.12-3.12.12-4.el9_7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.x86_64.rpm
+        evr: 3.12.12-4.el9_7.2
+        sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.2.x86_64.rpm
         repoid: ubi-9-for-x86_64-appstream-rpms
-        size: 10201800
-        checksum: sha256:11c7551ca41c44e1e3913a6dfb1107ad6a42cc707371676689584decbcf762e3
+        size: 10208752
+        checksum: sha256:b585cdcc008fb29fbccec4f0bc7cf1478930bd7c3103b380ea04ab66a7dac414
         name: python3.12-libs
-        evr: 3.12.12-4.el9_7
-        sourcerpm: python3.12-3.12.12-4.el9_7.src.rpm
+        evr: 3.12.12-4.el9_7.2
+        sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
         repoid: ubi-9-for-x86_64-appstream-rpms
         size: 1527128
@@ -2915,27 +2915,27 @@ arches:
         name: shadow-utils-subid
         evr: 2:4.9-15.el9
         sourcerpm: shadow-utils-4.9-15.el9.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-252-55.el9_7.7.x86_64.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-252-55.el9_7.8.x86_64.rpm
         repoid: ubi-9-for-x86_64-baseos-rpms
-        size: 4410717
-        checksum: sha256:19ea80e6fec0f3a3b1679da5b9051cca50e776c3d4213dc660cc212d668786f7
+        size: 4394529
+        checksum: sha256:02536e2255182db5ec2a8cc07fdda20062378247699b7bed5e0b0ea72b1ca783
         name: systemd
-        evr: 252-55.el9_7.7
-        sourcerpm: systemd-252-55.el9_7.7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-pam-252-55.el9_7.7.x86_64.rpm
+        evr: 252-55.el9_7.8
+        sourcerpm: systemd-252-55.el9_7.8.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-pam-252-55.el9_7.8.x86_64.rpm
         repoid: ubi-9-for-x86_64-baseos-rpms
-        size: 289346
-        checksum: sha256:fda74e652f6bc88ef357df96711ad71d98069ca0355c3cfe24b14fbe54257b24
+        size: 274195
+        checksum: sha256:3cb33a319f67824d3beb8b2f2356995695b4c3ac77ae66c8e6c3315ef822d0bc
         name: systemd-pam
-        evr: 252-55.el9_7.7
-        sourcerpm: systemd-252-55.el9_7.7.src.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-55.el9_7.7.noarch.rpm
+        evr: 252-55.el9_7.8
+        sourcerpm: systemd-252-55.el9_7.8.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-55.el9_7.8.noarch.rpm
         repoid: ubi-9-for-x86_64-baseos-rpms
-        size: 72275
-        checksum: sha256:dd54f47d3773db296cdff65dbc1fc423416a7d1bed7447a11c715a2017ae8760
+        size: 57061
+        checksum: sha256:807a9519d7a3f6b2168ca47666b43e1630b3fa82256e919633a07baa5906b1b2
         name: systemd-rpm-macros
-        evr: 252-55.el9_7.7
-        sourcerpm: systemd-252-55.el9_7.7.src.rpm
+        evr: 252-55.el9_7.8
+        sourcerpm: systemd-252-55.el9_7.8.src.rpm
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tar-1.34-9.el9_7.x86_64.rpm
         repoid: ubi-9-for-x86_64-baseos-rpms
         size: 906521
@@ -2970,12 +2970,12 @@ arches:
         checksum: sha256:935cde45890eee106b48c5a17fcce9a359bbc33e5867c7433012a28fdc095e90
         name: criu
         evr: 3.19-3.el9
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/c/crun-1.23.1-2.el9_7.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/c/crun-1.27-1.el9_7.src.rpm
         repoid: ubi-9-for-x86_64-appstream-source-rpms
-        size: 845412
-        checksum: sha256:19500c02ad50c34f29a7c69d69fb48a7675c9915a0656c272b82ccbf93bd32bd
+        size: 908477
+        checksum: sha256:0b6d37252bb27dedbc9770b7f968e1b903d8d8a2f0fa4cc0d6d201cb1a00d189
         name: crun
-        evr: 1.23.1-2.el9_7
+        evr: 1.27-1.el9_7
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.16-1.el9_7.src.rpm
         repoid: ubi-9-for-x86_64-appstream-source-rpms
         size: 127644
@@ -3018,12 +3018,12 @@ arches:
         checksum: sha256:2f5ece89d6a8d892816f386462d8be291ad83f1500b4c4b3655dcc7ed5192c0d
         name: mpdecimal
         evr: 2.5.1-3.el9
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.2.src.rpm
         repoid: ubi-9-for-x86_64-appstream-source-rpms
-        size: 20873997
-        checksum: sha256:1f4a8ae3002de2a536e58c42ec410bcd9cf3371c40b3b3d8efb2c58feece28f7
+        size: 20880557
+        checksum: sha256:0d4494e18c3a6b5c62c96ef5786561fc6fab96cd50f2380c1471d2eaeabd06fd
         name: python3.12
-        evr: 3.12.12-4.el9_7
+        evr: 3.12.12-4.el9_7.2
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/python3.12-pip-23.2.1-5.el9.src.rpm
         repoid: ubi-9-for-x86_64-appstream-source-rpms
         size: 9384965
@@ -3216,12 +3216,12 @@ arches:
         checksum: sha256:c6feefc65a20ec4203979e0cde4d4a6d86981ac7c836e55148273bd9fc2b57b2
         name: shadow-utils
         evr: 2:4.9-15.el9
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/s/systemd-252-55.el9_7.7.src.rpm
+      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/s/systemd-252-55.el9_7.8.src.rpm
         repoid: ubi-9-for-x86_64-baseos-source-rpms
-        size: 44902530
-        checksum: sha256:c3ec3a6af5ab03b57450f24d12297eaf66191292c699cec4f52ee47688159d9c
+        size: 44888096
+        checksum: sha256:a633587c7170f5928a0bf1ba144f8f58d759cfdcbc4e6437c4dcb74b1742c69b
         name: systemd
-        evr: 252-55.el9_7.7
+        evr: 252-55.el9_7.8
       - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/t/tar-1.34-9.el9_7.src.rpm
         repoid: ubi-9-for-x86_64-baseos-source-rpms
         size: 2282680

--- a/ubi.repo
+++ b/ubi.repo
@@ -8,14 +8,14 @@ gpgcheck = 1
 [ubi-9-for-$basearch-baseos-debug-rpms]
 name = Red Hat Universal Base Image 9 (Debug RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/debug
-enabled = 0
+enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
 [ubi-9-for-$basearch-baseos-source-rpms]
 name = Red Hat Universal Base Image 9 (Source RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/source/SRPMS
-enabled = 0
+enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
@@ -29,14 +29,14 @@ gpgcheck = 1
 [ubi-9-for-$basearch-appstream-debug-rpms]
 name = Red Hat Universal Base Image 9 (Debug RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/debug
-enabled = 0
+enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
 [ubi-9-for-$basearch-appstream-source-rpms]
 name = Red Hat Universal Base Image 9 (Source RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/source/SRPMS
-enabled = 0
+enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
@@ -50,13 +50,13 @@ gpgcheck = 1
 [codeready-builder-for-ubi-9-$basearch-debug-rpms]
 name = Red Hat Universal Base Image 9 (Debug RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/debug
-enabled = 0
+enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
 [codeready-builder-for-ubi-9-$basearch-source-rpms]
 name = Red Hat Universal Base Image 9 (Source RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/source/SRPMS
-enabled = 0
+enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1


### PR DESCRIPTION
## Summary
- Refreshed `rpms.lock.yaml` and `ubi.repo` for the `rhoai-2.25` branch
- Packages: skopeo, gcc, make, python3.12-devel, cargo, g++
- Architectures: x86_64, aarch64, ppc64le, s390x
- Base image: `ubi9/ubi-minimal`

## Test plan
- [ ] Verify Konflux build passes with updated lockfiles