### PR TITLE
fix: Workaround for hermeto not redirecting git output

### DIFF
--- a/jobs/async-upload/Dockerfile.konflux
+++ b/jobs/async-upload/Dockerfile.konflux
@@ -25,6 +25,29 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 COPY ./poetry.lock ./pyproject.toml ./requirements.txt ./
 
+# Hermeto dynamically generates .cargo/config.toml to redirect crates.io
+# sources to the local vendor directory. However, it does not apply the same
+# redirect for git-sourced dependencies (only registry sources are handled).
+# This causes cargo to attempt a live network fetch during a hermetic build.
+#
+# Workaround: Overwrite the generated config with one that also redirects the
+# known git source (pyca/cryptography) to the local vendor directory.
+#
+# Remove when: Hermeto supports vendoring and redirecting git-sourced Cargo deps.
+RUN cat <<EOF > /cachi2/output/.cargo/config.toml
+
+[source.crates-io]
+replace-with = "local"
+
+[source."git+https://github.com/pyca/cryptography.git?tag=45.0.4"]
+git = "https://github.com/pyca/cryptography.git"
+tag = "45.0.4"
+replace-with = "local"
+
+[source.local]
+directory = "/cachi2/output/deps/cargo"
+EOF
+
 # rfc3161-client has no pre-built wheels for ppc64le/s390x, so pip builds from
 # source via Rust/maturin. OPENSSL_NO_VENDOR tells openssl-sys to link against
 # the system OpenSSL instead of compiling its own (which requires perl).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Workaround for the hermeto issue here: https://redhat.atlassian.net/browse/STONEBLD-4547

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
