### PR TITLE
fix: sdist for rh-model-signing

### DIFF
--- a/jobs/async-upload/hermetic_fixes.sh
+++ b/jobs/async-upload/hermetic_fixes.sh
@@ -56,7 +56,25 @@ sed -i '/^\[build-system\]$/,/^build-backend = "uv_build"$/d' pyproject.toml
 python -m pip install .
 
 # -----------------------------------------------------------------------------
-# Fix #3 — hf-xet requires Rust ≥ 1.89.0, but the UBI9 base image ships 1.88.0
+# Fix #3 — rh-model-signing sdist has a broken hatch build config
+#
+# The sdist for rh-model-signing 0.1.0 places the model_signing package at the
+# archive root, but pyproject.toml declares packages = ["src/model_signing"]
+# (the source repo layout). hatch finds no files matching that path and installs
+# only metadata — zero Python modules end up in site-packages.
+#
+# Workaround: Extract the sdist, rewrite the hatch packages directive to point
+# at the actual location ("model_signing"), then install from the patched tree.
+#
+# Remove when: upstream ships an sdist/wheel with the correct build config.
+# -----------------------------------------------------------------------------
+tar -xzf /cachi2/output/deps/pip/rh_model_signing-0.1.0.tar.gz -C /tmp
+cd /tmp/rh_model_signing-0.1.0
+sed -i 's|packages = \["src/model_signing"\]|packages = ["model_signing"]|' pyproject.toml
+python -m pip install .
+
+# -----------------------------------------------------------------------------
+# Fix #4 — hf-xet requires Rust ≥ 1.89.0, but the UBI9 base image ships 1.88.0
 #
 # hf-xet (and its transitive dependencies) enforce a minimum Rust toolchain
 # version of 1.89.0. The UBI9 base image currently provides only 1.88.0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The sdist for rh-model-signing 0.1.0 fetched by hermeto places the model_signing package at the
archive root, but pyproject.toml declares packages = ["src/model_signing"]
(the source repo layout). hatch finds no files matching that path and installs
only metadata -- zero Python modules end up in site-packages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
