### PR TITLE
fix: strengthen Dockerfile sanity check to catch broken wheels

### DIFF
--- a/jobs/async-upload/Dockerfile.konflux
+++ b/jobs/async-upload/Dockerfile.konflux
@@ -47,9 +47,12 @@ USER 1000
 ENV PATH="/home/1000/.local/bin:$PATH"
 RUN ls -l /app
 
-# Sanity checks model_registry module import
-RUN echo "Testing model_registry import..." \
-&& python -c "import model_registry; print('model_registry package found')"
+# Sanity checks critical imports (catches broken/empty wheels at build time)
+RUN python -c "\
+import model_registry; \
+import model_signing; \
+from model_registry.signing import Signer; \
+print('all imports ok')"
 
 # TODO: unavailble in OCI format: Add an explicit health-check (K8s will surface this in Pod.status)
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \


### PR DESCRIPTION
## Summary
- Strengthen the import sanity check in both `Dockerfile` and `Dockerfile.konflux` to catch broken/empty wheels at build time
- The existing check only tests `import model_registry`, which succeeds even when `model_signing` is completely missing (the broken wheel has metadata but no source files)
- Now also tests `import model_signing` and `from model_registry.signing import Signer`

## Context
RHOAIENG-63943: The async-upload job crashes at startup because `rh-model-signing` was installed as a broken wheel (metadata only, zero source files). The build succeeded because the sanity check didn't test the signing imports.

This complements PR #1300 which fixes the hermetic build of `rh-model-signing`.

## Test plan
- [ ] Verify the build fails if `model_signing` is missing (broken wheel scenario)
- [ ] Verify the build succeeds when `model_signing` is correctly installed