### PR TITLE
fix: update Cargo redirect tag to match cryptography 46.0.7

### DIFF
--- a/jobs/async-upload/Dockerfile.konflux
+++ b/jobs/async-upload/Dockerfile.konflux
@@ -32,6 +32,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
       export OPENSSL_NO_VENDOR=1; \
     fi && \
     python -m pip install -r requirements.txt  \
+    && ./hermetic_fixes.sh post-install \
     && echo "Installation completed" \
     && echo "Python path:" && python -c "import sys; print('\\n'.join(sys.path))" \
     && echo "Installed packages:" \
@@ -47,12 +48,13 @@ USER 1000
 ENV PATH="/home/1000/.local/bin:$PATH"
 RUN ls -l /app
 
-# protobuf's native _upb C extension segfaults on s390x
-# (https://github.com/protocolbuffers/protobuf/issues/24103)
-ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
-
-# Sanity checks critical imports (catches broken/empty wheels at build time)
-RUN python -c "\
+# Sanity checks critical imports (catches broken/empty wheels at build time).
+# On s390x the native _upb wheel was already swapped for the pure-Python one
+# by hermetic_fixes.sh, but set the env var as a safety net.
+RUN if [ "$(uname -m)" = "s390x" ]; then \
+      export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python; \
+    fi && \
+    python -c "\
 import model_registry; \
 import model_signing; \
 from model_registry.signing import Signer; \

--- a/jobs/async-upload/Dockerfile.konflux
+++ b/jobs/async-upload/Dockerfile.konflux
@@ -48,15 +48,18 @@ ENV PATH="/home/1000/.local/bin:$PATH"
 RUN ls -l /app
 
 # Trace which sub-import inside model_signing segfaults (temporary)
-RUN python -c "\
-import sys; \
-_orig = __builtins__.__import__; \
-def _trace(name, *a, **kw): \
-    print(f'  importing: {name}', flush=True); \
-    return _orig(name, *a, **kw); \
-__builtins__.__import__ = _trace; \
-import model_signing; \
-print('model_signing: ok')" 2>&1 || echo ">>> SEGFAULT after last import above (exit $?)"
+RUN printf '%s\n' \
+      'import sys' \
+      '_orig = __builtins__.__import__' \
+      'def _trace(name, *a, **kw):' \
+      '    print(f"  importing: {name}", flush=True)' \
+      '    return _orig(name, *a, **kw)' \
+      '__builtins__.__import__ = _trace' \
+      'import model_signing' \
+      "print('model_signing: ok')" \
+      > /tmp/trace_imports.py && \
+    python /tmp/trace_imports.py 2>&1 || \
+    echo ">>> SEGFAULT after last import above (exit $?)"
 
 # Sanity checks critical imports (catches broken/empty wheels at build time)
 RUN python -c "\

--- a/jobs/async-upload/Dockerfile.konflux
+++ b/jobs/async-upload/Dockerfile.konflux
@@ -47,10 +47,10 @@ USER 1000
 ENV PATH="/home/1000/.local/bin:$PATH"
 RUN ls -l /app
 
-# Diagnose which native module segfaults on s390x (temporary — remove once resolved)
-RUN for mod in _cffi_backend cryptography rfc3161_client hf_xet blake3 pydantic_core rpds_py; do \
-      python -c "import $mod; print('$mod: ok')" || echo ">>> $mod: FAILED (exit $?)"; \
-    done
+# Diagnose which import segfaults on s390x (temporary — remove once resolved)
+RUN python -c "import model_registry; print('model_registry: ok')" || echo ">>> model_registry: FAILED (exit $?)"
+RUN python -c "import model_signing; print('model_signing: ok')" || echo ">>> model_signing: FAILED (exit $?)"
+RUN python -c "from model_registry.signing import Signer; print('Signer: ok')" || echo ">>> Signer: FAILED (exit $?)"
 
 # Sanity checks critical imports (catches broken/empty wheels at build time)
 RUN python -c "\

--- a/jobs/async-upload/Dockerfile.konflux
+++ b/jobs/async-upload/Dockerfile.konflux
@@ -47,6 +47,11 @@ USER 1000
 ENV PATH="/home/1000/.local/bin:$PATH"
 RUN ls -l /app
 
+# Diagnose which native module segfaults on s390x (temporary — remove once resolved)
+RUN for mod in _cffi_backend cryptography rfc3161_client hf_xet blake3 pydantic_core rpds_py; do \
+      python -c "import $mod; print('$mod: ok')" || echo ">>> $mod: FAILED (exit $?)"; \
+    done
+
 # Sanity checks critical imports (catches broken/empty wheels at build time)
 RUN python -c "\
 import model_registry; \

--- a/jobs/async-upload/Dockerfile.konflux
+++ b/jobs/async-upload/Dockerfile.konflux
@@ -47,19 +47,9 @@ USER 1000
 ENV PATH="/home/1000/.local/bin:$PATH"
 RUN ls -l /app
 
-# Trace which sub-import inside model_signing segfaults (temporary)
-RUN printf '%s\n' \
-      'import sys' \
-      '_orig = __builtins__.__import__' \
-      'def _trace(name, *a, **kw):' \
-      '    print(f"  importing: {name}", flush=True)' \
-      '    return _orig(name, *a, **kw)' \
-      '__builtins__.__import__ = _trace' \
-      'import model_signing' \
-      "print('model_signing: ok')" \
-      > /tmp/trace_imports.py && \
-    python /tmp/trace_imports.py 2>&1 || \
-    echo ">>> SEGFAULT after last import above (exit $?)"
+# protobuf's native _upb C extension segfaults on s390x
+# (https://github.com/protocolbuffers/protobuf/issues/24103)
+ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 
 # Sanity checks critical imports (catches broken/empty wheels at build time)
 RUN python -c "\

--- a/jobs/async-upload/Dockerfile.konflux
+++ b/jobs/async-upload/Dockerfile.konflux
@@ -47,10 +47,16 @@ USER 1000
 ENV PATH="/home/1000/.local/bin:$PATH"
 RUN ls -l /app
 
-# Diagnose which import segfaults on s390x (temporary — remove once resolved)
-RUN python -c "import model_registry; print('model_registry: ok')" || echo ">>> model_registry: FAILED (exit $?)"
-RUN python -c "import model_signing; print('model_signing: ok')" || echo ">>> model_signing: FAILED (exit $?)"
-RUN python -c "from model_registry.signing import Signer; print('Signer: ok')" || echo ">>> Signer: FAILED (exit $?)"
+# Trace which sub-import inside model_signing segfaults (temporary)
+RUN python -c "\
+import sys; \
+_orig = __builtins__.__import__; \
+def _trace(name, *a, **kw): \
+    print(f'  importing: {name}', flush=True); \
+    return _orig(name, *a, **kw); \
+__builtins__.__import__ = _trace; \
+import model_signing; \
+print('model_signing: ok')" 2>&1 || echo ">>> SEGFAULT after last import above (exit $?)"
 
 # Sanity checks critical imports (catches broken/empty wheels at build time)
 RUN python -c "\

--- a/jobs/async-upload/hermetic_fixes.sh
+++ b/jobs/async-upload/hermetic_fixes.sh
@@ -9,6 +9,14 @@ set -e
 # upstream condition that would make it safe to remove.
 # =============================================================================
 
+# s390x is big-endian; vendored OpenSSL compilation produces binaries that
+# segfault at runtime. Link against the system OpenSSL instead.
+# This must be set before any pip install that might build cryptography from
+# source (Fix #3 pulls it as a transitive dep of rh-model-signing).
+ARCH=$(uname -m)
+if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
+  export OPENSSL_NO_VENDOR=1
+fi
 
 # -----------------------------------------------------------------------------
 # Fix #1 — Cargo git source redirect missing from Hermeto-generated config

--- a/jobs/async-upload/hermetic_fixes.sh
+++ b/jobs/async-upload/hermetic_fixes.sh
@@ -20,6 +20,7 @@ set -e
 #
 # Workaround: Overwrite the generated config with one that also redirects the
 # known git source (pyca/cryptography) to the local vendor directory.
+# The tag MUST match the cryptography version in requirements.txt (currently 46.0.7).
 #
 # Remove when: Hermeto supports vendoring and redirecting git-sourced Cargo deps.
 # -----------------------------------------------------------------------------
@@ -28,9 +29,9 @@ cat <<EOF > /cachi2/output/.cargo/config.toml
 [source.crates-io]
 replace-with = "local"
 
-[source."git+https://github.com/pyca/cryptography.git?tag=45.0.4"]
+[source."git+https://github.com/pyca/cryptography.git?tag=46.0.7"]
 git = "https://github.com/pyca/cryptography.git"
-tag = "45.0.4"
+tag = "46.0.7"
 replace-with = "local"
 
 [source.local]

--- a/jobs/async-upload/hermetic_fixes.sh
+++ b/jobs/async-upload/hermetic_fixes.sh
@@ -95,3 +95,39 @@ python -m pip install .
 # Remove when: the UBI9 base image is updated to Rust ≥ 1.89.0.
 # -----------------------------------------------------------------------------
 MATURIN_PEP517_ARGS="--ignore-rust-version" pip install hf-xet
+
+# -----------------------------------------------------------------------------
+# Fix #5 — protobuf _upb C extension segfaults on s390x (post-install)
+#
+# Pip selects protobuf-7.34.0-cp310-abi3-manylinux2014_s390x.whl on s390x.
+# The bundled google/_upb/_message.abi3.so segfaults when generated protos
+# (e.g. in_toto_attestation) register descriptors, and again at interpreter
+# shutdown. PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python alone is insufficient
+# because the broken .so is still installed and may be loaded on exit.
+#
+# Workaround: After the main requirements install, replace protobuf with the
+# py3-none-any wheel vendored by Hermeto (no native _upb).
+#
+# Upstream: https://github.com/protocolbuffers/protobuf/issues/24103
+#
+# Remove when: a pinned protobuf release includes a verified s390x upb fix.
+# -----------------------------------------------------------------------------
+fix_protobuf_s390x() {
+  if [ "$(uname -m)" != "s390x" ]; then
+    return 0
+  fi
+
+  # Version MUST match protobuf in requirements.txt (currently 7.34.0).
+  PROTOBUF_WHEEL="/cachi2/output/deps/pip/protobuf-7.34.0-py3-none-any.whl"
+  if [ ! -f "$PROTOBUF_WHEEL" ]; then
+    echo "Fix #5: pure-Python protobuf wheel not found at $PROTOBUF_WHEEL" >&2
+    exit 1
+  fi
+
+  python -m pip uninstall -y protobuf
+  PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python python -m pip install --no-deps "$PROTOBUF_WHEEL"
+}
+
+if [ "${1:-}" = "post-install" ]; then
+  fix_protobuf_s390x
+fi


### PR DESCRIPTION
The hermetic build workaround in hermetic_fixes.sh redirected pyca/cryptography git source to tag 45.0.4, but requirements.txt has cryptography==46.0.7. On s390x (no pre-built wheels), pip builds from source via Cargo/maturin — the version mismatch produces a _rust.abi3.so with the wrong ABI, causing a segfault on import.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
