### PR TITLE
fix: revert pyca/cryptography version

### DIFF
--- a/jobs/async-upload/hermetic_fixes.sh
+++ b/jobs/async-upload/hermetic_fixes.sh
@@ -28,7 +28,6 @@ fi
 #
 # Workaround: Overwrite the generated config with one that also redirects the
 # known git source (pyca/cryptography) to the local vendor directory.
-# The tag MUST match the cryptography version in requirements.txt (currently 46.0.7).
 #
 # Remove when: Hermeto supports vendoring and redirecting git-sourced Cargo deps.
 # -----------------------------------------------------------------------------
@@ -37,14 +36,16 @@ cat <<EOF > /cachi2/output/.cargo/config.toml
 [source.crates-io]
 replace-with = "local"
 
-[source."git+https://github.com/pyca/cryptography.git?tag=46.0.7"]
+[source."git+https://github.com/pyca/cryptography.git?tag=45.0.4"]
 git = "https://github.com/pyca/cryptography.git"
-tag = "46.0.7"
+tag = "45.0.4"
 replace-with = "local"
 
 [source.local]
 directory = "/cachi2/output/deps/cargo"
 EOF
+# explicitly install the package here so we fail fast if the cargo redirect does not work
+pip install rfc3161-client
 
 # -----------------------------------------------------------------------------
 # Fix #2 — sigstore_models cannot be built via uv-build in a hermetic environment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The heremetic build is still expecting 45.0.4 as you can see in the logs: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5-ea-1/pipelineruns/odh-model-registry-job-async-upload-v3-5-ea-1-on-push-5wglh

```
        error: failed to get `cryptography-x509` as a dependency of package `rfc3161-client v0.0.1 (/tmp/pip-install-g5z0rihd/rfc3161-client_fd3a5e0a25024e2a898a0dafae6e340f/rust)`
        
        Caused by:
          failed to load source for dependency `cryptography-x509`
        
        Caused by:
          Unable to update https://github.com/pyca/cryptography.git?tag=45.0.4#678c0c59
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
