### PR TITLE
fix: use pure python protobufs to avoid segmentation fault s390x

### DIFF
--- a/jobs/async-upload/Dockerfile.konflux
+++ b/jobs/async-upload/Dockerfile.konflux
@@ -22,6 +22,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 COPY ./poetry.lock ./pyproject.toml ./requirements.txt ./
 
+ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 COPY ./hermetic_fixes.sh ./
 RUN ./hermetic_fixes.sh
 
@@ -32,7 +33,6 @@ RUN if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
       export OPENSSL_NO_VENDOR=1; \
     fi && \
     python -m pip install -r requirements.txt  \
-    && ./hermetic_fixes.sh post-install \
     && echo "Installation completed" \
     && echo "Python path:" && python -c "import sys; print('\\n'.join(sys.path))" \
     && echo "Installed packages:" \

--- a/jobs/async-upload/hermetic_fixes.sh
+++ b/jobs/async-upload/hermetic_fixes.sh
@@ -96,39 +96,3 @@ python -m pip install .
 # Remove when: the UBI9 base image is updated to Rust ≥ 1.89.0.
 # -----------------------------------------------------------------------------
 MATURIN_PEP517_ARGS="--ignore-rust-version" pip install hf-xet
-
-# -----------------------------------------------------------------------------
-# Fix #5 — protobuf _upb C extension segfaults on s390x (post-install)
-#
-# Pip selects protobuf-7.34.0-cp310-abi3-manylinux2014_s390x.whl on s390x.
-# The bundled google/_upb/_message.abi3.so segfaults when generated protos
-# (e.g. in_toto_attestation) register descriptors, and again at interpreter
-# shutdown. PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python alone is insufficient
-# because the broken .so is still installed and may be loaded on exit.
-#
-# Workaround: After the main requirements install, replace protobuf with the
-# py3-none-any wheel vendored by Hermeto (no native _upb).
-#
-# Upstream: https://github.com/protocolbuffers/protobuf/issues/24103
-#
-# Remove when: a pinned protobuf release includes a verified s390x upb fix.
-# -----------------------------------------------------------------------------
-fix_protobuf_s390x() {
-  if [ "$(uname -m)" != "s390x" ]; then
-    return 0
-  fi
-
-  # Version MUST match protobuf in requirements.txt (currently 7.34.0).
-  PROTOBUF_WHEEL="/cachi2/output/deps/pip/protobuf-7.34.0-py3-none-any.whl"
-  if [ ! -f "$PROTOBUF_WHEEL" ]; then
-    echo "Fix #5: pure-Python protobuf wheel not found at $PROTOBUF_WHEEL" >&2
-    exit 1
-  fi
-
-  python -m pip uninstall -y protobuf
-  PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python python -m pip install --no-deps "$PROTOBUF_WHEEL"
-}
-
-if [ "${1:-}" = "post-install" ]; then
-  fix_protobuf_s390x
-fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
