### PR TITLE
fix: make CORS configurable and disabled by default

### DIFF
--- a/catalog/cmd/catalog.go
+++ b/catalog/cmd/catalog.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -14,6 +16,7 @@ import (
 	"github.com/kubeflow/model-registry/catalog/internal/server/openapi"
 	"github.com/kubeflow/model-registry/internal/datastore"
 	"github.com/kubeflow/model-registry/internal/datastore/embedmd"
+	mrmiddleware "github.com/kubeflow/model-registry/internal/server/middleware"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +24,7 @@ var catalogCfg = struct {
 	ListenAddress          string
 	ConfigPath             []string
 	PerformanceMetricsPath []string
+	CORSAllowedOrigins     []string
 }{
 	ListenAddress:          "0.0.0.0:8080",
 	ConfigPath:             []string{"sources.yaml"},
@@ -42,9 +46,21 @@ func init() {
 	fs.StringVarP(&catalogCfg.ListenAddress, "listen", "l", catalogCfg.ListenAddress, "Address to listen on")
 	fs.StringSliceVar(&catalogCfg.ConfigPath, "catalogs-path", catalogCfg.ConfigPath, "Path to catalog source configuration file")
 	fs.StringSliceVar(&catalogCfg.PerformanceMetricsPath, "performance-metrics", catalogCfg.PerformanceMetricsPath, "Path to performance metrics data directory")
+	fs.StringSliceVar(&catalogCfg.CORSAllowedOrigins, "cors-allowed-origins", nil,
+		"Comma-separated list of allowed CORS origins. If empty (default), CORS is disabled. Can also be set via CATALOG_CORS_ALLOWED_ORIGINS environment variable.")
 }
 
 func runCatalogServer(cmd *cobra.Command, args []string) error {
+	if !cmd.Flags().Changed("cors-allowed-origins") {
+		if envVal := os.Getenv("CATALOG_CORS_ALLOWED_ORIGINS"); envVal != "" {
+			for _, origin := range strings.Split(envVal, ",") {
+				if o := strings.TrimSpace(origin); o != "" {
+					catalogCfg.CORSAllowedOrigins = append(catalogCfg.CORSAllowedOrigins, o)
+				}
+			}
+		}
+	}
+
 	ds, err := datastore.NewConnector("embedmd", &embedmd.EmbedMDConfig{
 		DatabaseType: "postgres", // We only support postgres right now
 		DatabaseDSN:  "",         // Empty DSN, see https://www.postgresql.org/docs/current/libpq-envars.html
@@ -95,7 +111,7 @@ func runCatalogServer(cmd *cobra.Command, args []string) error {
 	ctrl := openapi.NewModelCatalogServiceAPIController(svc)
 
 	glog.Infof("Catalog API server listening on %s", catalogCfg.ListenAddress)
-	return http.ListenAndServe(catalogCfg.ListenAddress, openapi.NewRouter(ctrl))
+	return http.ListenAndServe(catalogCfg.ListenAddress, mrmiddleware.CORSMiddleware(catalogCfg.CORSAllowedOrigins)(openapi.NewRouter(ctrl)))
 }
 
 func getRepo[T any](repoSet datastore.RepoSet) T {

--- a/catalog/internal/server/openapi/routers.go
+++ b/catalog/internal/server/openapi/routers.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/cors"
 )
 
 //lint:file-ignore U1000 Ignore all unused code, it's generated
@@ -40,14 +39,6 @@ type Router interface {
 func NewRouter(routers ...Router) chi.Router {
 	router := chi.NewRouter()
 	router.Use(Logger)
-	router.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{"https://*", "http://*"},
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-PINGOTHER"},
-		ExposedHeaders:   []string{"Link"},
-		AllowCredentials: false,
-		MaxAge:           300, // Maximum value not ignored by any of major browsers
-	}))
 	for _, api := range routers {
 		for _, route := range api.OrderedRoutes() {
 			var handler http.Handler = route.HandlerFunc

--- a/catalog/scripts/gen_openapi_server.sh
+++ b/catalog/scripts/gen_openapi_server.sh
@@ -12,7 +12,7 @@ DST="$PROJECT_ROOT/${2:-internal/server/openapi}"
 
 "$OPENAPI_GENERATOR" generate \
     -i "$SRC" -g go-server -o "$DST" --package-name openapi \
-    --ignore-file-override "$PROJECT_ROOT"/.openapi-generator-ignore --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true,featureCORS=true \
+    --ignore-file-override "$PROJECT_ROOT"/.openapi-generator-ignore --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true \
     --template-dir "$PROJECT_ROOT"/../templates/go-server
 
 # Python-based regex replace function

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,10 +1,11 @@
 package cmd
 
 type Config struct {
-	DbFile      string   `mapstructure:"db-file" yaml:"db-file"`
-	Hostname    string   `mapstructure:"hostname" yaml:"hostname"`
-	Port        int      `mapstructure:"port" yaml:"port"`
-	LibraryDirs []string `mapstructure:"metadata-library-dir" yaml:"metadata-library-dir"`
+	DbFile             string   `mapstructure:"db-file" yaml:"db-file"`
+	Hostname           string   `mapstructure:"hostname" yaml:"hostname"`
+	Port               int      `mapstructure:"port" yaml:"port"`
+	LibraryDirs        []string `mapstructure:"metadata-library-dir" yaml:"metadata-library-dir"`
+	CORSAllowedOrigins []string `mapstructure:"cors-allowed-origins" yaml:"cors-allowed-origins"`
 }
 
 var cfg = Config{DbFile: "metadata.sqlite.db", Hostname: "localhost", Port: 8080, LibraryDirs: []string(nil)}

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -170,7 +170,7 @@ func runProxyServer(cmd *cobra.Command, args []string) error {
 		ModelRegistryServiceAPIService := openapi.NewModelRegistryServiceAPIService(conn)
 		ModelRegistryServiceAPIController := openapi.NewModelRegistryServiceAPIController(ModelRegistryServiceAPIService)
 
-		router.SetRouter(middleware.WrapWithValidation(ModelRegistryServiceAPIController))
+		router.SetRouter(middleware.WrapWithValidation(cfg.CORSAllowedOrigins, ModelRegistryServiceAPIController))
 
 		// Set the model registry service in the holder for health checks AFTER router is ready
 		// This ensures the readiness probe only passes when the router can serve actual requests
@@ -249,4 +249,7 @@ func init() {
 	proxyCmd.Flags().BoolVar(&proxyCfg.EmbedMD.TLSConfig.VerifyServerCert, "embedmd-database-ssl-verify-server-cert", false, "EmbedMD SSL verify server cert")
 
 	proxyCmd.Flags().StringVar(&proxyCfg.DatastoreType, "datastore-type", proxyCfg.DatastoreType, "Datastore type")
+
+	proxyCmd.Flags().StringSliceVar(&cfg.CORSAllowedOrigins, "cors-allowed-origins", nil,
+		"Comma-separated list of allowed CORS origins. If empty (default), CORS is disabled. Can also be set via MR_CORS_ALLOWED_ORIGINS environment variable.")
 }

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.39.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.39.0
 	go.uber.org/zap v1.27.0
-	golang.org/x/crypto v0.53.0
 	google.golang.org/protobuf v1.36.10
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.0
@@ -149,6 +148,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -530,8 +530,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
-golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -547,8 +545,6 @@ golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
-golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
 golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -566,8 +562,6 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
-golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
 golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -582,8 +576,6 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -608,20 +600,14 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=
-golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
 golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
 golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
-golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
 golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -643,8 +629,6 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
-golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
 golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
 golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/server/middleware/cors.go
+++ b/internal/server/middleware/cors.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/go-chi/cors"
+)
+
+// CORSMiddleware returns a CORS middleware handler. If allowedOrigins is empty,
+// the returned middleware is a no-op, making CORS effectively disabled.
+// This is the secure default: deployments that do not explicitly configure
+// allowed origins will not accept cross-origin requests.
+func CORSMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
+	if len(allowedOrigins) == 0 {
+		return func(next http.Handler) http.Handler {
+			return next
+		}
+	}
+
+	return cors.Handler(cors.Options{
+		AllowedOrigins:   allowedOrigins,
+		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
+		ExposedHeaders:   []string{"Link"},
+		AllowCredentials: false,
+		MaxAge:           300,
+	})
+}

--- a/internal/server/middleware/cors_test.go
+++ b/internal/server/middleware/cors_test.go
@@ -1,0 +1,156 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func dummyHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+}
+
+func TestCORSMiddleware_Disabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		origins []string
+	}{
+		{"nil origins", nil},
+		{"empty slice", []string{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := CORSMiddleware(tc.origins)(dummyHandler())
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.Header.Set("Origin", "https://evil.com")
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}
+
+func TestCORSMiddleware_AllowsConfiguredOrigin(t *testing.T) {
+	handler := CORSMiddleware([]string{"https://dashboard.example.com"})(dummyHandler())
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "https://dashboard.example.com", rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSMiddleware_RejectsUnconfiguredOrigin(t *testing.T) {
+	handler := CORSMiddleware([]string{"https://dashboard.example.com"})(dummyHandler())
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://evil.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSMiddleware_PreflightAllowed(t *testing.T) {
+	handler := CORSMiddleware([]string{"https://dashboard.example.com"})(dummyHandler())
+
+	req := httptest.NewRequest("OPTIONS", "/test", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "https://dashboard.example.com", rr.Header().Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, rr.Header().Get("Access-Control-Allow-Methods"), "POST")
+}
+
+func TestCORSMiddleware_PreflightDisabled(t *testing.T) {
+	handler := CORSMiddleware(nil)(dummyHandler())
+
+	req := httptest.NewRequest("OPTIONS", "/test", nil)
+	req.Header.Set("Origin", "https://evil.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSMiddleware_WildcardOrigin(t *testing.T) {
+	handler := CORSMiddleware([]string{"*"})(dummyHandler())
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://any-site.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSMiddleware_MultipleOrigins(t *testing.T) {
+	origins := []string{"https://dashboard.example.com", "https://admin.example.com"}
+	handler := CORSMiddleware(origins)(dummyHandler())
+
+	for _, origin := range origins {
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Origin", origin)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, origin, rr.Header().Get("Access-Control-Allow-Origin"),
+			"expected origin %s to be allowed", origin)
+	}
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://other.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSMiddleware_CredentialsDisabled(t *testing.T) {
+	handler := CORSMiddleware([]string{"https://dashboard.example.com"})(dummyHandler())
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Credentials"))
+}
+
+func TestCORSMiddleware_PreflightPATCH(t *testing.T) {
+	handler := CORSMiddleware([]string{"https://dashboard.example.com"})(dummyHandler())
+
+	req := httptest.NewRequest("OPTIONS", "/test", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	req.Header.Set("Access-Control-Request-Method", "PATCH")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "https://dashboard.example.com", rr.Header().Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, rr.Header().Get("Access-Control-Allow-Methods"), "PATCH")
+}

--- a/internal/server/middleware/router.go
+++ b/internal/server/middleware/router.go
@@ -6,11 +6,12 @@ import (
 	"github.com/kubeflow/model-registry/internal/server/openapi"
 )
 
-// WrapWithValidation wraps the auto-generated router with custom validation middleware
-func WrapWithValidation(routers ...openapi.Router) http.Handler {
-	// Create the auto-generated router
+// WrapWithValidation wraps the auto-generated router with CORS and validation middleware.
+// If corsAllowedOrigins is empty, CORS is disabled (no cross-origin headers are added).
+func WrapWithValidation(corsAllowedOrigins []string, routers ...openapi.Router) http.Handler {
 	baseRouter := openapi.NewRouter(routers...)
 
-	// Wrap it with our custom validation middleware
-	return ValidationMiddleware(baseRouter)
+	handler := CORSMiddleware(corsAllowedOrigins)(baseRouter)
+
+	return ValidationMiddleware(handler)
 }

--- a/internal/server/middleware/router_test.go
+++ b/internal/server/middleware/router_test.go
@@ -1,0 +1,68 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubeflow/model-registry/internal/server/openapi"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubRouter struct{}
+
+func (s *stubRouter) Routes() openapi.Routes {
+	return openapi.Routes{
+		"test": {Name: "test", Method: "GET", Pattern: "/test", HandlerFunc: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+		}},
+	}
+}
+
+func (s *stubRouter) OrderedRoutes() []openapi.Route {
+	routes := s.Routes()
+	result := make([]openapi.Route, 0, len(routes))
+	for _, r := range routes {
+		result = append(result, r)
+	}
+	return result
+}
+
+func TestWrapWithValidation_CORSDisabled(t *testing.T) {
+	handler := WrapWithValidation(nil, &stubRouter{})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://evil.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestWrapWithValidation_CORSEnabled(t *testing.T) {
+	handler := WrapWithValidation([]string{"https://dashboard.example.com"}, &stubRouter{})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "https://dashboard.example.com", rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestWrapWithValidation_CORSAndValidation(t *testing.T) {
+	handler := WrapWithValidation([]string{"https://dashboard.example.com"}, &stubRouter{})
+
+	req := httptest.NewRequest("GET", "/test?name=test%00invalid", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}

--- a/internal/server/openapi/routers.go
+++ b/internal/server/openapi/routers.go
@@ -12,7 +12,6 @@ package openapi
 
 import (
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/cors"
 	"net/http"
 )
 
@@ -39,14 +38,6 @@ type Router interface {
 func NewRouter(routers ...Router) chi.Router {
 	router := chi.NewRouter()
 	router.Use(Logger)
-	router.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{"https://*", "http://*"},
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-PINGOTHER"},
-		ExposedHeaders:   []string{"Link"},
-		AllowCredentials: false,
-		MaxAge:           300, // Maximum value not ignored by any of major browsers
-	}))
 	for _, api := range routers {
 		for _, route := range api.OrderedRoutes() {
 			var handler http.Handler = route.HandlerFunc

--- a/scripts/gen_openapi_server.sh
+++ b/scripts/gen_openapi_server.sh
@@ -9,7 +9,7 @@ OPENAPI_GENERATOR=${OPENAPI_GENERATOR:-"$PROJECT_ROOT"/bin/openapi-generator-cli
 
 $OPENAPI_GENERATOR generate \
     -i "$PROJECT_ROOT"/api/openapi/model-registry.yaml -g go-server -o "$PROJECT_ROOT"/internal/server/openapi --package-name openapi \
-    --ignore-file-override "$PROJECT_ROOT"/.openapi-generator-ignore --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true,featureCORS=true \
+    --ignore-file-override "$PROJECT_ROOT"/.openapi-generator-ignore --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true \
     --template-dir "$PROJECT_ROOT"/templates/go-server
 
 echo "Assembling type_assert Go file"

--- a/templates/go-server/routers.mustache
+++ b/templates/go-server/routers.mustache
@@ -6,15 +6,9 @@ import (
 {{#routers}}
 	{{#mux}}
 	"github.com/gorilla/mux"
-	{{#featureCORS}}
-	"github.com/gorilla/handlers"
-	{{/featureCORS}}
 	{{/mux}}
 	{{#chi}}
 	"github.com/go-chi/chi/v5"
-	{{#featureCORS}}
-	"github.com/go-chi/cors"
-	{{/featureCORS}}
 	{{/chi}}
 {{/routers}}
 )
@@ -47,16 +41,6 @@ func NewRouter(routers ...Router) {{#routers}}{{#mux}}*mux.Router{{/mux}}{{#chi}
 	{{#chi}}
 	router := chi.NewRouter()
 	router.Use(Logger)
-	{{#featureCORS}}
-	router.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{"https://*", "http://*"},
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-PINGOTHER"},
-		ExposedHeaders:   []string{"Link"},
-		AllowCredentials: false,
-		MaxAge:           300, // Maximum value not ignored by any of major browsers
-	}))
-	{{/featureCORS}}
 	{{/chi}}
 {{/routers}}
 	for _, api := range routers {
@@ -65,9 +49,6 @@ func NewRouter(routers ...Router) {{#routers}}{{#mux}}*mux.Router{{/mux}}{{#chi}
 {{#routers}}
 	{{#mux}}
 			handler = Logger(handler, route.Name)
-			{{#featureCORS}}
-			handler = handlers.CORS()(handler)
-			{{/featureCORS}}
 
 			router.
 				Methods(route.Method).


### PR DESCRIPTION
## Description
Backport of [f804c848](https://github.com/red-hat-data-services/model-registry/commit/f804c84886759c31ef17479c27ef2d10496fdb20) from `rhoai-3.4` to `rhoai-3.3`. Removes hardcoded permissive CORS wildcards (https://*,http://*) from generated OpenAPI routers and replaces them with a --cors-allowed-origins flag that defaults to empty (CORS disabled).

- Add shared CORSMiddleware in internal/server/middleware/
- Wire --cors-allowed-origins flag for proxy (MR_CORS_ALLOWED_ORIGINS)
- Wire --cors-allowed-origins flag for catalog (CATALOG_CORS_ALLOWED_ORIGINS)
- Remove featureCORS from codegen templates and scripts
- Secure-by-default: empty origins = CORS disabled

Addresses CWE-942 (Permissive Cross-domain Policy with Untrusted Domains)

Ref: [RHOAIENG-76594](https://redhat.atlassian.net/browse/RHOAIENG-76594)

## How Has This Been Tested?
Unit tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
