### PR TITLE
feat(csi): add artifact URI allowlist and cloud metadata blocklist

### DIFF
--- a/cmd/csi/internal/storage/modelregistry_provider.go
+++ b/cmd/csi/internal/storage/modelregistry_provider.go
@@ -28,14 +28,16 @@ var (
 )
 
 type ModelRegistryProvider struct {
-	Client    *openapi.APIClient
-	Providers map[kserve.Protocol]kserve.Provider
+	Client       *openapi.APIClient
+	Providers    map[kserve.Protocol]kserve.Provider
+	URIValidator *URIValidator
 }
 
-func NewModelRegistryProvider(client *openapi.APIClient) (*ModelRegistryProvider, error) {
+func NewModelRegistryProvider(client *openapi.APIClient, allowedURIPrefixes []string) (*ModelRegistryProvider, error) {
 	return &ModelRegistryProvider{
-		Client:    client,
-		Providers: map[kserve.Protocol]kserve.Provider{},
+		Client:       client,
+		Providers:    map[kserve.Protocol]kserve.Provider{},
+		URIValidator: NewURIValidator(allowedURIPrefixes),
 	}, nil
 }
 
@@ -103,6 +105,11 @@ func (p *ModelRegistryProvider) DownloadModel(modelDir string, modelName string,
 	protocol, err := p.extractProtocol(*modelArtifact.Uri)
 	if err != nil {
 		return err
+	}
+
+	log.Printf("Validating artifact URI against allowlist: %s", safeString(modelArtifact.Uri))
+	if err := p.URIValidator.Validate(*modelArtifact.Uri); err != nil {
+		return fmt.Errorf("artifact URI validation failed: %w", err)
 	}
 
 	log.Printf("Getting KServe provider for protocol: %s", protocol)

--- a/cmd/csi/internal/storage/modelregistry_provider_test.go
+++ b/cmd/csi/internal/storage/modelregistry_provider_test.go
@@ -13,7 +13,8 @@ func TestParseModelVersion(t *testing.T) {
 	client := openapi.NewAPIClient(cfg)
 
 	provider := &ModelRegistryProvider{
-		Client: client,
+		Client:       client,
+		URIValidator: NewURIValidator(nil),
 	}
 
 	tests := []struct {
@@ -88,6 +89,72 @@ func TestParseModelVersion(t *testing.T) {
 					assert.NotNil(t, version)
 					assert.Equal(t, *tt.expectedVersion, *version)
 				}
+			}
+		})
+	}
+}
+
+func TestExtractProtocol(t *testing.T) {
+	provider := &ModelRegistryProvider{}
+
+	tests := []struct {
+		name        string
+		storageURI  string
+		expected    string
+		expectError bool
+		expectedErr error
+	}{
+		{
+			name:       "s3 protocol",
+			storageURI: "s3://bucket/key",
+			expected:   "s3://",
+		},
+		{
+			name:       "gs protocol",
+			storageURI: "gs://bucket/key",
+			expected:   "gs://",
+		},
+		{
+			name:       "https protocol",
+			storageURI: "https://example.com/model",
+			expected:   "https://",
+		},
+		{
+			name:       "http protocol",
+			storageURI: "http://example.com/model",
+			expected:   "http://",
+		},
+		{
+			name:        "empty string",
+			storageURI:  "",
+			expectError: true,
+			expectedErr: ErrNoStorageURI,
+		},
+		{
+			name:        "unsupported protocol",
+			storageURI:  "ftp://example.com/model",
+			expectError: true,
+			expectedErr: ErrProtocolNotSupported,
+		},
+		{
+			name:        "no protocol",
+			storageURI:  "just-a-string",
+			expectError: true,
+			expectedErr: ErrNoProtocolInSTorageURI,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			protocol, err := provider.extractProtocol(tt.storageURI)
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.expectedErr != nil {
+					assert.ErrorIs(t, err, tt.expectedErr)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, string(protocol))
 			}
 		})
 	}

--- a/cmd/csi/internal/storage/uri_validator.go
+++ b/cmd/csi/internal/storage/uri_validator.go
@@ -1,0 +1,92 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+var (
+	ErrArtifactURIBlocked    = errors.New("artifact URI targets a blocked endpoint")
+	ErrArtifactURINotAllowed = errors.New("artifact URI does not match any allowed prefix")
+)
+
+var blockedHosts = []string{
+	"169.254.169.254",
+	"fd00:ec2::254",
+	"metadata.google.internal",
+	"metadata.goog",
+}
+
+type URIValidator struct {
+	AllowedPrefixes []string
+}
+
+func NewURIValidator(allowedPrefixes []string) *URIValidator {
+	var filtered []string
+	for _, p := range allowedPrefixes {
+		if p != "" {
+			filtered = append(filtered, p)
+		}
+	}
+	return &URIValidator{
+		AllowedPrefixes: filtered,
+	}
+}
+
+func (v *URIValidator) Validate(artifactURI string) error {
+	parsed, err := url.Parse(artifactURI)
+	if err != nil {
+		return fmt.Errorf("%w: unable to parse URI %q: %v", ErrArtifactURIBlocked, artifactURI, err)
+	}
+
+	host := parsed.Host
+	if host == "" {
+		host = parsed.Opaque
+		if idx := strings.Index(host, "/"); idx != -1 {
+			host = host[:idx]
+		}
+	}
+
+	if host != "" && isBlockedHost(host) {
+		return fmt.Errorf("%w: host %q is a known cloud metadata or link-local endpoint", ErrArtifactURIBlocked, host)
+	}
+
+	if len(v.AllowedPrefixes) == 0 {
+		return nil
+	}
+
+	for _, prefix := range v.AllowedPrefixes {
+		if strings.HasPrefix(artifactURI, prefix) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%w: URI %q does not match any entry in allowlist %v", ErrArtifactURINotAllowed, artifactURI, v.AllowedPrefixes)
+}
+
+func isBlockedHost(host string) bool {
+	hostname := host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		hostname = h
+	}
+	hostname = strings.TrimPrefix(strings.TrimSuffix(hostname, "]"), "[")
+	hostname = strings.TrimSuffix(hostname, ".")
+	hostname = strings.ToLower(hostname)
+
+	for _, blocked := range blockedHosts {
+		if hostname == blocked {
+			return true
+		}
+	}
+
+	if ip := net.ParseIP(hostname); ip != nil {
+		if ip.IsLinkLocalUnicast() {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/csi/internal/storage/uri_validator_test.go
+++ b/cmd/csi/internal/storage/uri_validator_test.go
@@ -1,0 +1,253 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestURIValidatorValidate(t *testing.T) {
+	tests := []struct {
+		name            string
+		allowedPrefixes []string
+		artifactURI     string
+		expectError     bool
+		expectedErr     error
+	}{
+		// Blocklist: cloud metadata endpoints blocked regardless of allowlist
+		{
+			name:        "block AWS metadata endpoint",
+			artifactURI: "http://169.254.169.254/latest/meta-data/",
+			expectError: true,
+			expectedErr: ErrArtifactURIBlocked,
+		},
+		{
+			name:        "block AWS metadata IMDSv2",
+			artifactURI: "https://169.254.169.254/latest/api/token",
+			expectError: true,
+			expectedErr: ErrArtifactURIBlocked,
+		},
+		{
+			name:        "block AWS IPv6 metadata",
+			artifactURI: "http://[fd00:ec2::254]/latest/meta-data/",
+			expectError: true,
+			expectedErr: ErrArtifactURIBlocked,
+		},
+		{
+			name:        "block GCP metadata endpoint",
+			artifactURI: "http://metadata.google.internal/computeMetadata/v1/",
+			expectError: true,
+			expectedErr: ErrArtifactURIBlocked,
+		},
+		{
+			name:        "block metadata with non-standard port",
+			artifactURI: "http://169.254.169.254:8080/something",
+			expectError: true,
+			expectedErr: ErrArtifactURIBlocked,
+		},
+		{
+			name:        "block metadata IP in s3 URI",
+			artifactURI: "s3://169.254.169.254/bucket/key",
+			expectError: true,
+			expectedErr: ErrArtifactURIBlocked,
+		},
+		{
+			name:        "block AWS IPv6 metadata with port",
+			artifactURI: "http://[fd00:ec2::254]:8080/latest/meta-data/",
+			expectError: true,
+			expectedErr: ErrArtifactURIBlocked,
+		},
+		{
+			name:        "block link-local address in range",
+			artifactURI: "http://169.254.42.42/exfiltrate",
+			expectError: true,
+			expectedErr: ErrArtifactURIBlocked,
+		},
+		{
+			name:        "block GCP metadata.goog endpoint",
+			artifactURI: "http://metadata.goog/computeMetadata/v1/",
+			expectError: true,
+			expectedErr: ErrArtifactURIBlocked,
+		},
+		{
+			name:        "block trailing dot hostname bypass",
+			artifactURI: "http://metadata.google.internal./computeMetadata/v1/",
+			expectError: true,
+			expectedErr: ErrArtifactURIBlocked,
+		},
+		{
+			name:        "block trailing dot metadata.goog bypass",
+			artifactURI: "http://metadata.goog./computeMetadata/v1/",
+			expectError: true,
+			expectedErr: ErrArtifactURIBlocked,
+		},
+		{
+			name:        "block uppercase hostname bypass",
+			artifactURI: "http://METADATA.GOOGLE.INTERNAL/computeMetadata/v1/",
+			expectError: true,
+			expectedErr: ErrArtifactURIBlocked,
+		},
+		{
+			name:            "blocklist overrides allowlist",
+			allowedPrefixes: []string{"http://169.254.169.254/"},
+			artifactURI:     "http://169.254.169.254/latest/",
+			expectError:     true,
+			expectedErr:     ErrArtifactURIBlocked,
+		},
+
+		// Empty allowlist: backward compatibility, all non-blocked URIs accepted
+		{
+			name:        "empty allowlist accepts s3",
+			artifactURI: "s3://any-bucket/model.tar.gz",
+			expectError: false,
+		},
+		{
+			name:        "empty allowlist accepts gs",
+			artifactURI: "gs://any-bucket/model.tar.gz",
+			expectError: false,
+		},
+		{
+			name:        "empty allowlist accepts https",
+			artifactURI: "https://example.com/models/model.tar.gz",
+			expectError: false,
+		},
+		{
+			name:        "empty allowlist accepts http",
+			artifactURI: "http://example.com/models/model.tar.gz",
+			expectError: false,
+		},
+		{
+			name:            "nil allowlist accepts all",
+			allowedPrefixes: nil,
+			artifactURI:     "s3://any-bucket/any-path",
+			expectError:     false,
+		},
+
+		// Allowlist matching: only matching prefixes accepted
+		{
+			name:            "allowlist match with prefix",
+			allowedPrefixes: []string{"s3://my-bucket/"},
+			artifactURI:     "s3://my-bucket/models/v1/model.tar.gz",
+			expectError:     false,
+		},
+		{
+			name:            "allowlist exact match",
+			allowedPrefixes: []string{"s3://my-bucket/"},
+			artifactURI:     "s3://my-bucket/",
+			expectError:     false,
+		},
+		{
+			name:            "allowlist rejects non-matching bucket",
+			allowedPrefixes: []string{"s3://my-bucket/"},
+			artifactURI:     "s3://evil-bucket/payload",
+			expectError:     true,
+			expectedErr:     ErrArtifactURINotAllowed,
+		},
+		{
+			name:            "allowlist rejects non-matching protocol",
+			allowedPrefixes: []string{"s3://my-bucket/"},
+			artifactURI:     "https://example.com/model.tar.gz",
+			expectError:     true,
+			expectedErr:     ErrArtifactURINotAllowed,
+		},
+		{
+			name:            "multiple allowlist entries",
+			allowedPrefixes: []string{"s3://my-bucket/", "gs://trusted/"},
+			artifactURI:     "gs://trusted/model.bin",
+			expectError:     false,
+		},
+		{
+			name:            "multiple allowlist entries rejects non-matching",
+			allowedPrefixes: []string{"s3://my-bucket/", "gs://trusted/"},
+			artifactURI:     "gs://other-bucket/model.bin",
+			expectError:     true,
+			expectedErr:     ErrArtifactURINotAllowed,
+		},
+
+		// Protocol-only allowlist entries
+		{
+			name:            "protocol-only allowlist accepts matching protocol",
+			allowedPrefixes: []string{"s3://"},
+			artifactURI:     "s3://any-bucket/any-path",
+			expectError:     false,
+		},
+		{
+			name:            "protocol-only allowlist rejects different protocol",
+			allowedPrefixes: []string{"s3://"},
+			artifactURI:     "gs://any-bucket/any-path",
+			expectError:     true,
+			expectedErr:     ErrArtifactURINotAllowed,
+		},
+
+		// Empty prefix must not bypass allowlist
+		{
+			name:            "empty prefix in allowlist does not match everything",
+			allowedPrefixes: []string{"", "s3://my-bucket/"},
+			artifactURI:     "gs://evil-bucket/payload",
+			expectError:     true,
+			expectedErr:     ErrArtifactURINotAllowed,
+		},
+
+		// Trailing slash subtlety
+		{
+			name:            "no trailing slash matches similar bucket names",
+			allowedPrefixes: []string{"s3://my-bucket"},
+			artifactURI:     "s3://my-bucket-evil/payload",
+			expectError:     false,
+		},
+		{
+			name:            "trailing slash prevents similar bucket name match",
+			allowedPrefixes: []string{"s3://my-bucket/"},
+			artifactURI:     "s3://my-bucket-evil/payload",
+			expectError:     true,
+			expectedErr:     ErrArtifactURINotAllowed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := NewURIValidator(tt.allowedPrefixes)
+			err := validator.Validate(tt.artifactURI)
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.expectedErr != nil {
+					assert.ErrorIs(t, err, tt.expectedErr)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsBlockedHost(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		blocked bool
+	}{
+		{"AWS metadata IP", "169.254.169.254", true},
+		{"AWS metadata with port", "169.254.169.254:8080", true},
+		{"AWS IPv6 metadata", "[fd00:ec2::254]", true},
+		{"AWS IPv6 metadata unbracketed", "fd00:ec2::254", true},
+		{"AWS IPv6 metadata with port", "[fd00:ec2::254]:8080", true},
+		{"GCP metadata hostname", "metadata.google.internal", true},
+		{"GCP metadata.goog hostname", "metadata.goog", true},
+		{"GCP metadata trailing dot", "metadata.google.internal.", true},
+		{"GCP metadata.goog trailing dot", "metadata.goog.", true},
+		{"uppercase hostname", "METADATA.GOOGLE.INTERNAL", true},
+		{"mixed case hostname", "Metadata.Google.Internal", true},
+		{"link-local address", "169.254.1.1", true},
+		{"normal S3 host", "my-bucket", false},
+		{"normal hostname", "example.com", false},
+		{"normal IP", "10.0.0.1", false},
+		{"localhost", "127.0.0.1", false},
+		{"empty host", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.blocked, isBlockedHost(tt.host))
+		})
+	}
+}

--- a/cmd/csi/main.go
+++ b/cmd/csi/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"strings"
 
 	"github.com/kubeflow/model-registry/cmd/csi/internal/modelregistry"
 	"github.com/kubeflow/model-registry/cmd/csi/internal/storage"
@@ -14,6 +15,7 @@ const (
 	modelRegistrySchemeEnv            = "MODEL_REGISTRY_SCHEME"
 	modelRegistryServiceNameEnv       = "MODEL_REGISTRY_SERVICE_NAME"
 	modelRegistryClusterDomainEnv     = "MODEL_REGISTRY_CLUSTER_DOMAIN"
+	allowedArtifactURIPrefixesEnv     = "ALLOWED_ARTIFACT_URI_PREFIXES"
 	modelRegistryBaseUrlDefault       = "localhost:8080"
 	modelRegistrySchemeDefault        = "http"
 	modelRegistryServiceNameDefault   = "model-registry-service"
@@ -50,13 +52,25 @@ func main() {
 		clusterDomain = modelRegistryClusterDomainDefault
 	}
 
+	var allowedPrefixes []string
+	if prefixesStr, ok := os.LookupEnv(allowedArtifactURIPrefixesEnv); ok && prefixesStr != "" {
+		for _, p := range strings.Split(prefixesStr, ",") {
+			if trimmed := strings.TrimSpace(p); trimmed != "" {
+				allowedPrefixes = append(allowedPrefixes, trimmed)
+			}
+		}
+		log.Printf("Artifact URI allowlist configured with %d prefix(es): %v", len(allowedPrefixes), allowedPrefixes)
+	} else {
+		log.Printf("No artifact URI allowlist configured (%s not set), all URIs will be accepted", allowedArtifactURIPrefixesEnv)
+	}
+
 	cfg := openapi.NewConfiguration()
 	cfg.Host = baseUrl
 	cfg.Scheme = scheme
 
 	apiClient := modelregistry.NewAPIClient(cfg, sourceUri, serviceName, clusterDomain)
 
-	provider, err := storage.NewModelRegistryProvider(apiClient)
+	provider, err := storage.NewModelRegistryProvider(apiClient, allowedPrefixes)
 	if err != nil {
 		log.Fatalf("Error initiliazing model registry provider: %v", err)
 	}

--- a/manifests/kustomize/options/csi/clusterstoragecontainer.yaml
+++ b/manifests/kustomize/options/csi/clusterstoragecontainer.yaml
@@ -9,6 +9,12 @@ spec:
     env:
     - name: MODEL_REGISTRY_BASE_URL
       value: "model-registry-service.kubeflow.svc.cluster.local:8080"
+    # Uncomment to restrict artifact URIs the storage-initializer will download.
+    # Comma-separated list of URI prefixes. If unset, all URIs with supported
+    # protocols are allowed. Use trailing slashes to avoid partial bucket name
+    # matches (e.g., "s3://my-bucket/" not "s3://my-bucket").
+    # - name: ALLOWED_ARTIFACT_URI_PREFIXES
+    #   value: "s3://my-trusted-bucket/,gs://my-gcs-bucket/"
     resources:
       requests:
         memory: 100Mi


### PR DESCRIPTION
## Description
Add configurable URI prefix allowlist (ALLOWED_ARTIFACT_URI_PREFIXES) and hardcoded cloud metadata blocklist to the CSI storage-initializer to prevent SSRF attacks where attacker-controlled artifact URIs could exfiltrate cloud credentials via KServe provider downloads.

Defense-in-depth: empty allowlist preserves backward compatibility, only cloud metadata endpoints (169.254.169.254, fd00:ec2::254, metadata.google.internal) are unconditionally blocked.

Cherry-picked from `rhoai-3.5` commit [27cb0f46](https://github.com/red-hat-data-services/model-registry/commit/27cb0f4656bc534d9c725df86b7175329ec7982e).

Ref: [RHOAIENG-76598](https://redhat.atlassian.net/browse/RHOAIENG-76598)

## How Has This Been Tested?
Unit Tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
