### PR TITLE
feat(csi): add artifact URI allowlist and cloud metadata blocklist

### DIFF
--- a/cmd/csi/main.go
+++ b/cmd/csi/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"strings"
 
 	"github.com/kubeflow/model-registry/internal/csi/modelregistry"
 	"github.com/kubeflow/model-registry/internal/csi/storage"
@@ -10,10 +11,11 @@ import (
 )
 
 const (
-	modelRegistryBaseUrlEnv     = "MODEL_REGISTRY_BASE_URL"
-	modelRegistrySchemeEnv      = "MODEL_REGISTRY_SCHEME"
-	modelRegistryBaseUrlDefault = "localhost:8080"
-	modelRegistrySchemeDefault  = "http"
+	modelRegistryBaseUrlEnv       = "MODEL_REGISTRY_BASE_URL"
+	modelRegistrySchemeEnv        = "MODEL_REGISTRY_SCHEME"
+	allowedArtifactURIPrefixesEnv = "ALLOWED_ARTIFACT_URI_PREFIXES"
+	modelRegistryBaseUrlDefault   = "localhost:8080"
+	modelRegistrySchemeDefault    = "http"
 )
 
 func main() {
@@ -36,13 +38,25 @@ func main() {
 		scheme = modelRegistrySchemeDefault
 	}
 
+	var allowedPrefixes []string
+	if prefixesStr, ok := os.LookupEnv(allowedArtifactURIPrefixesEnv); ok && prefixesStr != "" {
+		for _, p := range strings.Split(prefixesStr, ",") {
+			if trimmed := strings.TrimSpace(p); trimmed != "" {
+				allowedPrefixes = append(allowedPrefixes, trimmed)
+			}
+		}
+		log.Printf("Artifact URI allowlist configured with %d prefix(es): %v", len(allowedPrefixes), allowedPrefixes)
+	} else {
+		log.Printf("No artifact URI allowlist configured (%s not set), all URIs will be accepted", allowedArtifactURIPrefixesEnv)
+	}
+
 	cfg := openapi.NewConfiguration()
 	cfg.Host = baseUrl
 	cfg.Scheme = scheme
 
 	apiClient := modelregistry.NewAPIClient(cfg, sourceUri)
 
-	provider, err := storage.NewModelRegistryProvider(apiClient)
+	provider, err := storage.NewModelRegistryProvider(apiClient, allowedPrefixes)
 	if err != nil {
 		log.Fatalf("Error initiliazing model registry provider: %v", err)
 	}

--- a/internal/csi/storage/modelregistry_provider.go
+++ b/internal/csi/storage/modelregistry_provider.go
@@ -29,14 +29,16 @@ var (
 )
 
 type ModelRegistryProvider struct {
-	Client    *openapi.APIClient
-	Providers map[kserve.Protocol]kserve.Provider
+	Client       *openapi.APIClient
+	Providers    map[kserve.Protocol]kserve.Provider
+	URIValidator *URIValidator
 }
 
-func NewModelRegistryProvider(client *openapi.APIClient) (*ModelRegistryProvider, error) {
+func NewModelRegistryProvider(client *openapi.APIClient, allowedURIPrefixes []string) (*ModelRegistryProvider, error) {
 	return &ModelRegistryProvider{
-		Client:    client,
-		Providers: map[kserve.Protocol]kserve.Provider{},
+		Client:       client,
+		Providers:    map[kserve.Protocol]kserve.Provider{},
+		URIValidator: NewURIValidator(allowedURIPrefixes),
 	}, nil
 }
 
@@ -104,6 +106,11 @@ func (p *ModelRegistryProvider) DownloadModel(modelDir string, modelName string,
 	protocol, err := p.extractProtocol(*modelArtifact.Uri)
 	if err != nil {
 		return err
+	}
+
+	log.Printf("Validating artifact URI against allowlist: %s", apiutils.SafeString(modelArtifact.Uri))
+	if err := p.URIValidator.Validate(*modelArtifact.Uri); err != nil {
+		return fmt.Errorf("artifact URI validation failed: %w", err)
 	}
 
 	log.Printf("Getting KServe provider for protocol: %s", protocol)

--- a/internal/csi/storage/modelregistry_provider_test.go
+++ b/internal/csi/storage/modelregistry_provider_test.go
@@ -1,0 +1,42 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractProtocol(t *testing.T) {
+	provider := &ModelRegistryProvider{
+		URIValidator: NewURIValidator(nil),
+	}
+
+	tests := []struct {
+		name        string
+		uri         string
+		expected    string
+		expectError error
+	}{
+		{"s3 protocol", "s3://my-bucket/model.tar.gz", "s3://", nil},
+		{"gs protocol", "gs://my-bucket/model/", "gs://", nil},
+		{"https protocol", "https://example.com/model.tar.gz", "https://", nil},
+		{"http protocol", "http://example.com/model.tar.gz", "http://", nil},
+		{"empty URI", "", "", ErrNoStorageURI},
+		{"no protocol", "my-bucket/model.tar.gz", "", ErrNoProtocolInSTorageURI},
+		{"unsupported protocol", "ftp://example.com/model.tar.gz", "", ErrProtocolNotSupported},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			protocol, err := provider.extractProtocol(tt.uri)
+			if tt.expectError != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.expectError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, string(protocol))
+			}
+		})
+	}
+}

--- a/internal/csi/storage/uri_validator.go
+++ b/internal/csi/storage/uri_validator.go
@@ -1,0 +1,92 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+var (
+	ErrArtifactURIBlocked    = errors.New("artifact URI targets a blocked endpoint")
+	ErrArtifactURINotAllowed = errors.New("artifact URI does not match any allowed prefix")
+)
+
+var blockedHosts = []string{
+	"169.254.169.254",
+	"fd00:ec2::254",
+	"metadata.google.internal",
+	"metadata.goog",
+}
+
+type URIValidator struct {
+	AllowedPrefixes []string
+}
+
+func NewURIValidator(allowedPrefixes []string) *URIValidator {
+	var filtered []string
+	for _, p := range allowedPrefixes {
+		if p != "" {
+			filtered = append(filtered, p)
+		}
+	}
+	return &URIValidator{
+		AllowedPrefixes: filtered,
+	}
+}
+
+func (v *URIValidator) Validate(artifactURI string) error {
+	parsed, err := url.Parse(artifactURI)
+	if err != nil {
+		return fmt.Errorf("%w: unable to parse URI %q: %v", ErrArtifactURIBlocked, artifactURI, err)
+	}
+
+	host := parsed.Host
+	if host == "" {
+		host = parsed.Opaque
+		if idx := strings.Index(host, "/"); idx != -1 {
+			host = host[:idx]
+		}
+	}
+
+	if host != "" && isBlockedHost(host) {
+		return fmt.Errorf("%w: host %q is a known cloud metadata or link-local endpoint", ErrArtifactURIBlocked, host)
+	}
+
+	if len(v.AllowedPrefixes) == 0 {
+		return nil
+	}
+
+	for _, prefix := range v.AllowedPrefixes {
+		if strings.HasPrefix(artifactURI, prefix) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%w: URI %q does not match any entry in allowlist %v", ErrArtifactURINotAllowed, artifactURI, v.AllowedPrefixes)
+}
+
+func isBlockedHost(host string) bool {
+	hostname := host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		hostname = h
+	}
+	hostname = strings.TrimPrefix(strings.TrimSuffix(hostname, "]"), "[")
+	hostname = strings.TrimSuffix(hostname, ".")
+	hostname = strings.ToLower(hostname)
+
+	for _, blocked := range blockedHosts {
+		if hostname == blocked {
+			return true
+		}
+	}
+
+	if ip := net.ParseIP(hostname); ip != nil {
+		if ip.IsLinkLocalUnicast() {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/csi/storage/uri_validator_test.go
+++ b/internal/csi/storage/uri_validator_test.go
@@ -1,0 +1,194 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestURIValidator_Validate_BlockedHosts(t *testing.T) {
+	validator := NewURIValidator(nil)
+
+	tests := []struct {
+		name string
+		uri  string
+	}{
+		{"AWS metadata IPv4", "http://169.254.169.254/latest/meta-data/"},
+		{"AWS metadata IMDSv2", "https://169.254.169.254/latest/api/token"},
+		{"AWS metadata with port", "http://169.254.169.254:80/latest/meta-data/"},
+		{"AWS metadata non-standard port", "http://169.254.169.254:8080/something"},
+		{"AWS metadata IPv6", "http://[fd00:ec2::254]/latest/meta-data/token"},
+		{"AWS metadata IPv6 with port", "http://[fd00:ec2::254]:8080/latest/meta-data/"},
+		{"AWS metadata in s3 opaque URI", "s3://169.254.169.254/bucket/key"},
+		{"GCP metadata", "http://metadata.google.internal/computeMetadata/v1/"},
+		{"GCP metadata alt", "http://metadata.goog/computeMetadata/v1/"},
+		{"GCP metadata uppercase", "http://METADATA.GOOGLE.INTERNAL/computeMetadata/v1/"},
+		{"GCP metadata trailing dot", "http://metadata.google.internal./computeMetadata/v1/"},
+		{"GCP metadata.goog trailing dot", "http://metadata.goog./computeMetadata/v1/"},
+		{"link-local other", "http://169.254.42.42/something"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.Validate(tt.uri)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrArtifactURIBlocked), "expected ErrArtifactURIBlocked, got: %v", err)
+		})
+	}
+}
+
+func TestURIValidator_Validate_AllowedURIs(t *testing.T) {
+	validator := NewURIValidator(nil)
+
+	tests := []struct {
+		name string
+		uri  string
+	}{
+		{"S3 URI", "s3://my-bucket/model.tar.gz"},
+		{"GCS URI", "gs://my-bucket/model/"},
+		{"HTTPS URI", "https://example.com/models/v1.tar.gz"},
+		{"HTTP URI", "http://internal-host:9000/model.bin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.Validate(tt.uri)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestURIValidator_Validate_AllowlistEnforcement(t *testing.T) {
+	validator := NewURIValidator([]string{"s3://trusted-bucket/", "gs://my-gcs-bucket/"})
+
+	tests := []struct {
+		name      string
+		uri       string
+		expectErr bool
+		errType   error
+	}{
+		{"allowed S3 prefix", "s3://trusted-bucket/model.tar.gz", false, nil},
+		{"allowed GCS prefix", "gs://my-gcs-bucket/path/model.bin", false, nil},
+		{"allowed exact match", "s3://trusted-bucket/", false, nil},
+		{"denied S3 different bucket", "s3://untrusted-bucket/model.tar.gz", true, ErrArtifactURINotAllowed},
+		{"denied HTTPS", "https://example.com/model.tar.gz", true, ErrArtifactURINotAllowed},
+		{"blocked always wins over allowlist", "http://169.254.169.254/latest/", true, ErrArtifactURIBlocked},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.Validate(tt.uri)
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tt.errType), "expected %v, got: %v", tt.errType, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestURIValidator_Validate_EmptyAllowlist(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefixes []string
+	}{
+		{"nil prefixes", nil},
+		{"empty slice", []string{}},
+		{"only empty strings", []string{"", ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := NewURIValidator(tt.prefixes)
+			err := validator.Validate("s3://any-bucket/model.tar.gz")
+			assert.NoError(t, err, "empty allowlist should accept all non-blocked URIs")
+		})
+	}
+}
+
+func TestURIValidator_Validate_ProtocolOnlyAllowlist(t *testing.T) {
+	validator := NewURIValidator([]string{"s3://"})
+
+	err := validator.Validate("s3://any-bucket/any-path")
+	assert.NoError(t, err, "protocol-only prefix should match any bucket")
+
+	err = validator.Validate("gs://any-bucket/any-path")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrArtifactURINotAllowed),
+		"protocol-only prefix should reject different protocols")
+}
+
+func TestURIValidator_Validate_EmptyPrefixBypass(t *testing.T) {
+	validator := NewURIValidator([]string{"", "s3://my-bucket/"})
+
+	err := validator.Validate("gs://evil-bucket/payload")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrArtifactURINotAllowed),
+		"empty prefix in allowlist must not match everything")
+}
+
+func TestURIValidator_Validate_TrailingSlashSubtlety(t *testing.T) {
+	noSlash := NewURIValidator([]string{"s3://my-bucket"})
+	err := noSlash.Validate("s3://my-bucket-evil/payload")
+	assert.NoError(t, err, "without trailing slash, similar bucket names match (documents the footgun)")
+
+	withSlash := NewURIValidator([]string{"s3://my-bucket/"})
+	err = withSlash.Validate("s3://my-bucket-evil/model.tar.gz")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrArtifactURINotAllowed),
+		"trailing slash in prefix should prevent partial bucket name matches")
+
+	err = withSlash.Validate("s3://my-bucket/model.tar.gz")
+	assert.NoError(t, err)
+}
+
+func TestURIValidator_Validate_BlocklistOverridesAllowlist(t *testing.T) {
+	validator := NewURIValidator([]string{"http://169.254.169.254/"})
+
+	err := validator.Validate("http://169.254.169.254/latest/meta-data/")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrArtifactURIBlocked),
+		"blocklist should take precedence even when URI matches an allowlist entry")
+}
+
+func TestNewURIValidator_FiltersEmptyPrefixes(t *testing.T) {
+	validator := NewURIValidator([]string{"s3://bucket/", "", "gs://other/", ""})
+	assert.Equal(t, []string{"s3://bucket/", "gs://other/"}, validator.AllowedPrefixes)
+}
+
+func TestIsBlockedHost(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		blocked bool
+	}{
+		{"AWS IPv4", "169.254.169.254", true},
+		{"AWS IPv4 with port", "169.254.169.254:80", true},
+		{"AWS IPv4 non-standard port", "169.254.169.254:8080", true},
+		{"AWS IPv6 bracketed", "[fd00:ec2::254]", true},
+		{"AWS IPv6 unbracketed", "fd00:ec2::254", true},
+		{"AWS IPv6 with port", "[fd00:ec2::254]:8080", true},
+		{"GCP internal", "metadata.google.internal", true},
+		{"GCP goog", "metadata.goog", true},
+		{"GCP trailing dot", "metadata.google.internal.", true},
+		{"GCP goog trailing dot", "metadata.goog.", true},
+		{"GCP uppercase", "METADATA.GOOGLE.INTERNAL", true},
+		{"GCP mixed case", "Metadata.Google.Internal", true},
+		{"link-local other", "169.254.42.42", true},
+		{"link-local range", "169.254.1.1", true},
+		{"normal host", "example.com", false},
+		{"normal S3 host", "my-bucket", false},
+		{"normal IP", "10.0.0.1", false},
+		{"localhost", "127.0.0.1", false},
+		{"empty host", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.blocked, isBlockedHost(tt.host))
+		})
+	}
+}

--- a/manifests/kustomize/options/csi/clusterstoragecontainer.yaml
+++ b/manifests/kustomize/options/csi/clusterstoragecontainer.yaml
@@ -9,6 +9,12 @@ spec:
     env:
     - name: MODEL_REGISTRY_BASE_URL
       value: "model-registry-service.kubeflow.svc.cluster.local:8080"
+    # Uncomment to restrict artifact URIs the storage-initializer will download.
+    # Comma-separated list of URI prefixes. If unset, all URIs with supported
+    # protocols are allowed. Use trailing slashes to avoid partial bucket name
+    # matches (e.g., "s3://my-bucket/" not "s3://my-bucket").
+    # - name: ALLOWED_ARTIFACT_URI_PREFIXES
+    #   value: "s3://my-trusted-bucket/,gs://my-gcs-bucket/"
     resources:
       requests:
         memory: 100Mi


### PR DESCRIPTION
## Description
Add configurable URI prefix allowlist (ALLOWED_ARTIFACT_URI_PREFIXES) and hardcoded cloud metadata blocklist to the CSI storage-initializer to prevent SSRF attacks where attacker-controlled artifact URIs could exfiltrate cloud credentials via KServe provider downloads.

Defense-in-depth: empty allowlist preserves backward compatibility, only cloud metadata endpoints (169.254.169.254, fd00:ec2::254, metadata.google.internal) are unconditionally blocked.

Backported from `rhoai-3.4` commit [f513041d](https://github.com/red-hat-data-services/model-registry/commit/f513041d5dd6416aafa786d33effec116a63fc48).

## How Has This Been Tested?
Unit tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
