### PR TITLE
lowercase supported microcopy fix

### DIFF
--- a/clients/ui/frontend/src/app/pages/mcpCatalog/components/__tests__/McpCatalogCard.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/components/__tests__/McpCatalogCard.spec.tsx
@@ -100,9 +100,9 @@ describe('McpCatalogCard', () => {
   });
 
   it.each([
-    ['partnerSupported', 'Partner Supported', '6'],
-    ['redHatSupported', 'Red Hat Supported', '7'],
-    ['communitySupported', 'Community Supported', '8'],
+    ['partnerSupported', 'Partner supported', '6'],
+    ['redHatSupported', 'Red Hat supported', '7'],
+    ['communitySupported', 'Community supported', '8'],
   ])('renders %s as "%s"', (tier, display, id) => {
     render(
       <McpCatalogCard

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/utils/mcpCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/utils/mcpCatalogUtils.ts
@@ -73,9 +73,9 @@ export enum SupportTier {
 }
 
 const SUPPORT_TIER_DISPLAY: Record<SupportTier, string> = {
-  [SupportTier.COMMUNITY]: 'Community Supported',
-  [SupportTier.PARTNER]: 'Partner Supported',
-  [SupportTier.RED_HAT]: 'Red Hat Supported',
+  [SupportTier.COMMUNITY]: 'Community supported',
+  [SupportTier.PARTNER]: 'Partner supported',
+  [SupportTier.RED_HAT]: 'Red Hat supported',
 };
 
 const SUPPORT_TIER_VALUES = new Set<string>(Object.values(SupportTier));


### PR DESCRIPTION
## Summary
- Cherry-pick ae801252d00dd9c304ccfe42ebf06d494abca05a onto `rhoai-3.5`
- Lowercase support-tier microcopy: "Community/Partner/Red Hat supported"

## Test plan
- [ ] Confirm MCP catalog card labels render as "Partner supported", "Red Hat supported", and "Community supported"
- [ ] Confirm related unit tests pass

Assisted-by: Cursor Grok 4.5

Made with [Cursor](https://cursor.com)