### PR TITLE
feat(async-upload): propagate trusted CA to transfer jobs

### DIFF
--- a/clients/ui/bff/internal/api/model_transfer_job_handler.go
+++ b/clients/ui/bff/internal/api/model_transfer_job_handler.go
@@ -149,7 +149,7 @@ func (app *App) CreateModelTransferJobHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	newJob, err := app.repositories.ModelRegistry.CreateModelTransferJob(ctx, client, namespace, payload, modelRegistryID, app.config.DeploymentMode.IsFederatedMode(), app.podNamespace)
+	newJob, err := app.repositories.ModelRegistry.CreateModelTransferJob(ctx, client, namespace, payload, modelRegistryID, app.config.DeploymentMode.IsFederatedMode(), app.podNamespace, app.config.BundlePaths)
 	if err != nil {
 		if errors.Is(err, repositories.ErrJobValidationFailed) {
 			app.badRequestResponse(w, r, err)
@@ -212,7 +212,7 @@ func (app *App) UpdateModelTransferJobHandler(w http.ResponseWriter, r *http.Req
 	deleteOldJob := r.URL.Query().Get("deleteOldJob") == "true"
 
 	updatedJob, err := app.repositories.ModelRegistry.UpdateModelTransferJob(
-		ctx, client, namespace, jobName, payload, deleteOldJob, modelRegistryID, app.config.DeploymentMode.IsFederatedMode(), app.podNamespace)
+		ctx, client, namespace, jobName, payload, deleteOldJob, modelRegistryID, app.config.DeploymentMode.IsFederatedMode(), app.podNamespace, app.config.BundlePaths)
 	if err != nil {
 		if errors.Is(err, repositories.ErrJobNotFound) {
 			app.notFoundResponse(w, r)

--- a/clients/ui/bff/internal/repositories/model_transfer_job_trust.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_job_trust.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"strings"
 
-	helper "github.com/kubeflow/hub/ui/bff/internal/helpers"
-	k8s "github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	helper "github.com/kubeflow/model-registry/ui/bff/internal/helpers"
+	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/clients/ui/bff/internal/repositories/model_transfer_job_trust.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_job_trust.go
@@ -1,0 +1,316 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+
+	helper "github.com/kubeflow/hub/ui/bff/internal/helpers"
+	k8s "github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	asyncUploadTrustedCAVolumeName          = "trusted-ca-bundle"
+	asyncUploadTrustedCAConfigMapName       = "odh-trusted-ca-bundle"
+	asyncUploadTrustedCAConfigMapNamePrefix = "trusted-ca-bundle-"
+	asyncUploadTrustedCAMountPath           = "/etc/pki/tls/custom"
+	asyncUploadTrustedCAFileName            = "ca-bundle.crt"
+	asyncUploadTrustedCAFilePath            = asyncUploadTrustedCAMountPath + "/" + asyncUploadTrustedCAFileName
+
+	asyncUploadDestinationTrustedCAVolumeName = "destination-trusted-ca"
+	asyncUploadDestinationCAConfigMapPrefix   = "destination-trusted-ca-"
+	asyncUploadDestinationCAFileName          = "ca.crt"
+	asyncUploadDestinationCAMountBasePath     = "/etc/containers/certs.d"
+
+	asyncUploadRegistrySecureAnnot      = "modelregistry.kubeflow.org/registry-secure"
+	asyncUploadTrustedCAConfigAnnot     = "modelregistry.kubeflow.org/trusted-ca-configmap"
+	asyncUploadTrustedCAPathAnnot       = "modelregistry.kubeflow.org/trusted-ca-path"
+	asyncUploadDestinationCAConfigAnnot = "modelregistry.kubeflow.org/destination-trusted-ca-configmap"
+	asyncUploadDestinationCAPathAnnot   = "modelregistry.kubeflow.org/destination-trusted-ca-path"
+)
+
+const (
+	asyncUploadOpenShiftServiceCAConfigMap    = "openshift-service-ca.crt"
+	asyncUploadOpenShiftServiceCAConfigMapKey = "service-ca.crt"
+	asyncUploadOpenShiftImageRegistryService  = "image-registry.openshift-image-registry.svc"
+)
+
+type asyncUploadResolvedTrust struct {
+	modelRegistryCAMount       *asyncUploadResolvedCAMount
+	destinationRegistryCAMount []asyncUploadResolvedCAMount
+	managedConfigMaps          []string
+}
+
+type asyncUploadResolvedCAMount struct {
+	configMapName       string
+	volumeName          string
+	mountPath           string
+	fileName            string
+	annotationConfigKey string
+	annotationPathKey   string
+	envVarName          string
+}
+
+func (m asyncUploadResolvedCAMount) filePath() string {
+	return m.mountPath + "/" + m.fileName
+}
+
+func resolveAsyncUploadTrust(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace string,
+	jobID string,
+	isFederatedMode bool,
+	modelRegistryAddress string,
+	destinationRegistry string,
+	bundlePaths []string,
+) (asyncUploadResolvedTrust, error) {
+	trust := asyncUploadResolvedTrust{}
+
+	_, registrySecure := parseRegistryServerAddress(modelRegistryAddress)
+	if registrySecure {
+		modelRegistryTrust, managedConfigMaps, err := resolveAsyncUploadModelRegistryTrust(
+			ctx,
+			client,
+			namespace,
+			jobID,
+			isFederatedMode,
+			bundlePaths,
+		)
+		if err != nil {
+			return trust, err
+		}
+		trust.modelRegistryCAMount = modelRegistryTrust
+		trust.managedConfigMaps = append(trust.managedConfigMaps, managedConfigMaps...)
+	}
+
+	destinationTrusts, managedConfigMaps, err := resolveAsyncUploadDestinationRegistryTrust(
+		ctx,
+		client,
+		namespace,
+		jobID,
+		destinationRegistry,
+	)
+	if err != nil {
+		return trust, err
+	}
+	trust.destinationRegistryCAMount = append(trust.destinationRegistryCAMount, destinationTrusts...)
+	trust.managedConfigMaps = append(trust.managedConfigMaps, managedConfigMaps...)
+
+	return trust, nil
+}
+
+func resolveAsyncUploadModelRegistryTrust(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace string,
+	jobID string,
+	isFederatedMode bool,
+	bundlePaths []string,
+) (*asyncUploadResolvedCAMount, []string, error) {
+	mount := &asyncUploadResolvedCAMount{
+		configMapName:       asyncUploadTrustedCAConfigMapName,
+		volumeName:          asyncUploadTrustedCAVolumeName,
+		mountPath:           asyncUploadTrustedCAMountPath,
+		fileName:            asyncUploadTrustedCAFileName,
+		annotationConfigKey: asyncUploadTrustedCAConfigAnnot,
+		annotationPathKey:   asyncUploadTrustedCAPathAnnot,
+		envVarName:          "MODEL_SYNC_REGISTRY_CUSTOM_CA",
+	}
+	if !isFederatedMode {
+		return mount, nil, nil
+	}
+
+	logger := helper.GetContextLogger(ctx)
+	// Federated mode: reuse the same CA material the BFF already trusts for outbound TLS
+	// (BUNDLE_PATHS / --bundle-paths). This avoids cross-namespace Secret reads that
+	// regular users cannot perform.
+	trustedCA := readLocalBundlePathsPEM(bundlePaths)
+	if trustedCA == "" {
+		logger.Warn(
+			"no readable bundle-paths CA for federated registry, falling back to namespace CA bundle",
+			"fallbackConfigMap", asyncUploadTrustedCAConfigMapName,
+		)
+		return mount, nil, nil
+	}
+
+	configMap, err := buildAsyncUploadGeneratedCAConfigMap(
+		asyncUploadTrustedCAConfigMapNamePrefix,
+		namespace,
+		jobID,
+		asyncUploadTrustedCAFileName,
+		trustedCA,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build model registry trusted CA configmap: %w", err)
+	}
+
+	configMapCreated, err := client.CreateConfigMap(ctx, namespace, configMap)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create model registry trusted CA configmap: %w", err)
+	}
+	if configMapCreated == nil || configMapCreated.Name == "" {
+		return nil, nil, fmt.Errorf("unexpected Kubernetes API behavior: model registry trusted CA configmap was nil or unnamed")
+	}
+
+	logger.Info(
+		"created model registry trusted CA configmap for async upload job from bundle-paths",
+		"namespace", namespace,
+		"name", configMapCreated.Name,
+	)
+	mount.configMapName = configMapCreated.Name
+	return mount, []string{configMapCreated.Name}, nil
+}
+
+func readLocalBundlePathsPEM(bundlePaths []string) string {
+	var parts []string
+	for _, p := range bundlePaths {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		pemBytes, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		trimmed := strings.TrimSpace(string(pemBytes))
+		if trimmed == "" {
+			continue
+		}
+		parts = append(parts, trimmed)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "\n")
+}
+
+func resolveAsyncUploadDestinationRegistryTrust(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace string,
+	jobID string,
+	destinationRegistry string,
+) ([]asyncUploadResolvedCAMount, []string, error) {
+	registryHost := normalizeRegistryHost(destinationRegistry)
+	if registryHost == "" || !isKnownClusterServiceRegistry(registryHost) {
+		return nil, nil, nil
+	}
+
+	logger := helper.GetContextLogger(ctx)
+	serviceCAConfigMap, err := client.GetConfigMap(ctx, namespace, asyncUploadOpenShiftServiceCAConfigMap)
+	if err != nil {
+		logger.Warn(
+			"failed to read platform service CA configmap, skipping destination registry trusted CA",
+			"namespace", namespace,
+			"configmap", asyncUploadOpenShiftServiceCAConfigMap,
+			"error", err,
+		)
+		return nil, nil, nil
+	}
+	if serviceCAConfigMap == nil {
+		return nil, nil, nil
+	}
+
+	serviceCA, found := serviceCAConfigMap.Data[asyncUploadOpenShiftServiceCAConfigMapKey]
+	if !found || strings.TrimSpace(serviceCA) == "" {
+		logger.Warn(
+			"platform service CA configmap missing expected certificate data, skipping destination registry trusted CA",
+			"namespace", namespace,
+			"configmap", asyncUploadOpenShiftServiceCAConfigMap,
+			"key", asyncUploadOpenShiftServiceCAConfigMapKey,
+		)
+		return nil, nil, nil
+	}
+
+	configMap, err := buildAsyncUploadGeneratedCAConfigMap(
+		asyncUploadDestinationCAConfigMapPrefix,
+		namespace,
+		jobID,
+		asyncUploadDestinationCAFileName,
+		serviceCA,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build destination registry trusted CA configmap: %w", err)
+	}
+
+	configMapCreated, err := client.CreateConfigMap(ctx, namespace, configMap)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create destination registry trusted CA configmap: %w", err)
+	}
+	if configMapCreated == nil || configMapCreated.Name == "" {
+		return nil, nil, fmt.Errorf("unexpected Kubernetes API behavior: destination registry trusted CA configmap was nil or unnamed")
+	}
+
+	logger.Info(
+		"created destination registry trusted CA configmap for async upload job",
+		"namespace", namespace,
+		"name", configMapCreated.Name,
+		"registry", registryHost,
+	)
+	return []asyncUploadResolvedCAMount{{
+		configMapName:       configMapCreated.Name,
+		volumeName:          asyncUploadDestinationTrustedCAVolumeName,
+		mountPath:           asyncUploadDestinationCAPath(registryHost),
+		fileName:            asyncUploadDestinationCAFileName,
+		annotationConfigKey: asyncUploadDestinationCAConfigAnnot,
+		annotationPathKey:   asyncUploadDestinationCAPathAnnot,
+	}}, []string{configMapCreated.Name}, nil
+}
+
+func buildAsyncUploadGeneratedCAConfigMap(generateNamePrefix, namespace, jobID, dataKey, trustedCA string) (*corev1.ConfigMap, error) {
+	if strings.TrimSpace(trustedCA) == "" {
+		return nil, fmt.Errorf("trusted CA content is empty")
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: generateNamePrefix,
+			Namespace:    namespace,
+			Labels: map[string]string{
+				"modelregistry.kubeflow.org/job-type": "async-upload",
+				"modelregistry.kubeflow.org/job-id":   jobID,
+			},
+		},
+		Data: map[string]string{
+			dataKey: trustedCA,
+		},
+	}, nil
+}
+
+func normalizeRegistryHost(registry string) string {
+	registry = strings.TrimSpace(registry)
+	if registry == "" {
+		return ""
+	}
+	if strings.Contains(registry, "://") {
+		u, err := url.Parse(registry)
+		if err == nil && u.Host != "" {
+			return u.Host
+		}
+	}
+	parts := strings.Split(registry, "/")
+	return parts[0]
+}
+
+func asyncUploadDestinationCAPath(registryHost string) string {
+	return asyncUploadDestinationCAMountBasePath + "/" + registryHost
+}
+
+func isKnownClusterServiceRegistry(registryHost string) bool {
+	registryHost = normalizeRegistryHost(registryHost)
+	if registryHost == "" {
+		return false
+	}
+	hostOnly := registryHost
+	if host, _, err := net.SplitHostPort(registryHost); err == nil {
+		hostOnly = host
+	}
+	return hostOnly == asyncUploadOpenShiftImageRegistryService ||
+		hostOnly == asyncUploadOpenShiftImageRegistryService+".cluster.local"
+}

--- a/clients/ui/bff/internal/repositories/model_transfer_jobs.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs.go
@@ -275,8 +275,8 @@ func convertK8sEventsToModelEvents(eventList *corev1.EventList) []models.ModelTr
 	return events
 }
 
-func (m *ModelRegistryRepository) CreateModelTransferJob(ctx context.Context, client k8s.KubernetesClientInterface, namespace string, payload models.ModelTransferJob, modelRegistryID string, isFederatedMode bool, podNamespace string) (*models.ModelTransferJob, error) {
-	return m.createModelTransferJobResources(ctx, client, namespace, payload, modelRegistryID, "", isFederatedMode, podNamespace)
+func (m *ModelRegistryRepository) CreateModelTransferJob(ctx context.Context, client k8s.KubernetesClientInterface, namespace string, payload models.ModelTransferJob, modelRegistryID string, isFederatedMode bool, podNamespace string, bundlePaths []string) (*models.ModelTransferJob, error) {
+	return m.createModelTransferJobResources(ctx, client, namespace, payload, modelRegistryID, "", isFederatedMode, podNamespace, bundlePaths)
 }
 
 func (m *ModelRegistryRepository) createModelTransferJobResources(
@@ -288,6 +288,7 @@ func (m *ModelRegistryRepository) createModelTransferJobResources(
 	existingDestSecretName string,
 	isFederatedMode bool,
 	podNamespace string,
+	bundlePaths []string,
 ) (*models.ModelTransferJob, error) {
 	payload.Source.Bucket = strings.TrimSpace(payload.Source.Bucket)
 	payload.Source.Key = strings.TrimSpace(payload.Source.Key)
@@ -313,7 +314,6 @@ func (m *ModelRegistryRepository) createModelTransferJobResources(
 
 	jobID := uuid.NewString()
 	jobName := payload.Name
-
 	var configMapName, sourceSecretName, destSecretName string
 	destSecretName = existingDestSecretName
 
@@ -348,11 +348,37 @@ func (m *ModelRegistryRepository) createModelTransferJobResources(
 		destSecretName = destSecretCreated.Name
 	}
 
+	trustConfig, err := resolveAsyncUploadTrust(
+		ctx,
+		client,
+		payload.Namespace,
+		jobID,
+		isFederatedMode,
+		modelRegistryAddress,
+		payload.Destination.Registry,
+		bundlePaths,
+	)
+	if err != nil {
+		cleanupCreatedResources(ctx, client, payload.Namespace, configMapName, sourceSecretName, destSecretName, trustConfig.managedConfigMaps...)
+		return nil, err
+	}
+
 	imageURI := resolveAsyncUploadImage(ctx, client, isFederatedMode, podNamespace)
-	job := buildK8sJob(jobName, jobID, payload, configMapName, sourceSecretName, destSecretName, modelRegistryAddress, modelRegistryID, imageURI)
+	job := buildK8sJob(
+		jobName,
+		jobID,
+		payload,
+		configMapName,
+		trustConfig,
+		sourceSecretName,
+		destSecretName,
+		modelRegistryAddress,
+		modelRegistryID,
+		imageURI,
+	)
 	jobCreated, err := client.CreateModelTransferJob(ctx, payload.Namespace, job)
 	if err != nil {
-		cleanupCreatedResources(ctx, client, payload.Namespace, configMapName, sourceSecretName, destSecretName)
+		cleanupCreatedResources(ctx, client, payload.Namespace, configMapName, sourceSecretName, destSecretName, trustConfig.managedConfigMaps...)
 		if apierrors.IsAlreadyExists(err) {
 			return nil, fmt.Errorf("%w: job '%s' already exists", ErrJobValidationFailed, jobName)
 		}
@@ -361,7 +387,7 @@ func (m *ModelRegistryRepository) createModelTransferJobResources(
 
 	if jobCreated == nil {
 		logger.Error("created job is nil - unexpected K8s client behavior")
-		cleanupCreatedResources(ctx, client, payload.Namespace, configMapName, sourceSecretName, destSecretName)
+		cleanupCreatedResources(ctx, client, payload.Namespace, configMapName, sourceSecretName, destSecretName, trustConfig.managedConfigMaps...)
 		if err := client.DeleteModelTransferJob(ctx, payload.Namespace, jobName); err != nil && !apierrors.IsNotFound(err) {
 			logger.Warn("failed to cleanup job after nil response", "jobName", jobName, "error", err)
 		}
@@ -377,6 +403,11 @@ func (m *ModelRegistryRepository) createModelTransferJobResources(
 
 	if err := client.PatchConfigMapOwnerReference(ctx, payload.Namespace, configMapName, ownerRef); err != nil {
 		logger.Warn("failed to set ownerReference on configmap", "error", err)
+	}
+	for _, generatedConfigMapName := range trustConfig.managedConfigMaps {
+		if err := client.PatchConfigMapOwnerReference(ctx, payload.Namespace, generatedConfigMapName, ownerRef); err != nil {
+			logger.Warn("failed to set ownerReference on generated trusted CA configmap", "name", generatedConfigMapName, "error", err)
+		}
 	}
 	if sourceSecretName != "" {
 		if err := client.PatchSecretOwnerReference(ctx, payload.Namespace, sourceSecretName, ownerRef); err != nil {
@@ -401,6 +432,7 @@ func (m *ModelRegistryRepository) UpdateModelTransferJob(
 	modelRegistryID string,
 	isFederatedMode bool,
 	podNamespace string,
+	bundlePaths []string,
 ) (*models.ModelTransferJob, error) {
 
 	logger := helper.GetContextLogger(ctx)
@@ -584,7 +616,7 @@ func (m *ModelRegistryRepository) UpdateModelTransferJob(
 		return nil, fmt.Errorf("validation error: %w", err)
 	}
 
-	result, err := m.createModelTransferJobResources(ctx, client, namespace, newPayload, modelRegistryID, existingDestSecretName, isFederatedMode, podNamespace)
+	result, err := m.createModelTransferJobResources(ctx, client, namespace, newPayload, modelRegistryID, existingDestSecretName, isFederatedMode, podNamespace, bundlePaths)
 	if err != nil {
 		if reuseDestCreds && existingDestSecretName != "" {
 			if delErr := client.DeleteSecret(ctx, newPayload.Namespace, existingDestSecretName); delErr != nil {
@@ -664,7 +696,7 @@ func resolveAsyncUploadImage(ctx context.Context, client k8s.KubernetesClientInt
 }
 
 func buildK8sJob(jobName, jobID string, payload models.ModelTransferJob,
-	configMapName, sourceSecretName, destSecretName, modelRegistryAddress, modelRegistryID, imageURI string) *batchv1.Job {
+	configMapName string, trustConfig asyncUploadResolvedTrust, sourceSecretName, destSecretName, modelRegistryAddress, modelRegistryID, imageURI string) *batchv1.Job {
 
 	backoffLimit := int32(3)
 
@@ -732,9 +764,56 @@ func buildK8sJob(jobName, jobID string, payload models.ModelTransferJob,
 		"modelregistry.kubeflow.org/author":              payload.Author,
 		"modelregistry.kubeflow.org/configmap-name":      configMapName,
 		"modelregistry.kubeflow.org/dest-secret":         destSecretName,
+		asyncUploadRegistrySecureAnnot:                   strconv.FormatBool(registrySecure),
 		"modelregistry.kubeflow.org/registered-model-id": payload.RegisteredModelId,
 		"modelregistry.kubeflow.org/model-version-id":    payload.ModelVersionId,
 		"modelregistry.kubeflow.org/model-artifact-id":   payload.ModelArtifactId,
+	}
+
+	if trustConfig.modelRegistryCAMount != nil {
+		modelRegistryCAMount := trustConfig.modelRegistryCAMount
+		volumes = append(volumes, corev1.Volume{
+			Name: modelRegistryCAMount.volumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: modelRegistryCAMount.configMapName,
+					},
+					Optional: func() *bool { b := true; return &b }(),
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      modelRegistryCAMount.volumeName,
+			MountPath: modelRegistryCAMount.mountPath,
+			ReadOnly:  true,
+		})
+		if modelRegistryCAMount.envVarName != "" {
+			envVars = append(envVars, corev1.EnvVar{Name: modelRegistryCAMount.envVarName, Value: modelRegistryCAMount.filePath()})
+		}
+		annotations[modelRegistryCAMount.annotationConfigKey] = modelRegistryCAMount.configMapName
+		annotations[modelRegistryCAMount.annotationPathKey] = modelRegistryCAMount.filePath()
+	}
+
+	for _, destinationRegistryCAMount := range trustConfig.destinationRegistryCAMount {
+		volumes = append(volumes, corev1.Volume{
+			Name: destinationRegistryCAMount.volumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: destinationRegistryCAMount.configMapName,
+					},
+					Optional: func() *bool { b := true; return &b }(),
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      destinationRegistryCAMount.volumeName,
+			MountPath: destinationRegistryCAMount.mountPath,
+			ReadOnly:  true,
+		})
+		annotations[destinationRegistryCAMount.annotationConfigKey] = destinationRegistryCAMount.configMapName
+		annotations[destinationRegistryCAMount.annotationPathKey] = destinationRegistryCAMount.filePath()
 	}
 
 	switch payload.Source.Type {
@@ -1108,12 +1187,21 @@ func validateCreatePayload(payload models.ModelTransferJob, skipDestCredsValidat
 	return nil
 }
 
-func cleanupCreatedResources(ctx context.Context, client k8s.KubernetesClientInterface, namespace, configMapName, sourceSecretName, destSecretName string) {
+func cleanupCreatedResources(ctx context.Context, client k8s.KubernetesClientInterface, namespace, configMapName, sourceSecretName, destSecretName string, extraConfigMapNames ...string) {
 	logger := helper.GetContextLogger(ctx)
 
-	if configMapName != "" {
-		if err := client.DeleteConfigMap(ctx, namespace, configMapName); err != nil {
-			logger.Warn("failed to cleanup configmap", "name", configMapName, "error", err)
+	configMapNames := append([]string{configMapName}, extraConfigMapNames...)
+	configMapNameSet := map[string]struct{}{}
+	for _, name := range configMapNames {
+		if name == "" {
+			continue
+		}
+		if _, seen := configMapNameSet[name]; seen {
+			continue
+		}
+		configMapNameSet[name] = struct{}{}
+		if err := client.DeleteConfigMap(ctx, namespace, name); err != nil {
+			logger.Warn("failed to cleanup configmap", "name", name, "error", err)
 		}
 	}
 	if sourceSecretName != "" {

--- a/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
@@ -683,69 +683,6 @@ func TestGetAllModelTransferJobs_NormalRunningJobNotOverridden(t *testing.T) {
 	}
 }
 
-func TestRegistryOriginOnly(t *testing.T) {
-	cases := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "ClusterIP with explicit port",
-			input:    "http://10.43.0.100:8080/api/model_registry/v1alpha3",
-			expected: "http://10.43.0.100:8080",
-		},
-		{
-			name:     "Route-based HTTPS (no explicit port)",
-			input:    "https://my-registry-rest.apps.example.com/api/model_registry/v1alpha3",
-			expected: "https://my-registry-rest.apps.example.com:443",
-		},
-		{
-			name:     "Route-based HTTPS with explicit port",
-			input:    "https://my-registry-rest.apps.example.com:443/api/model_registry/v1alpha3",
-			expected: "https://my-registry-rest.apps.example.com:443",
-		},
-		{
-			name:     "Gateway-based URL preserves path prefix",
-			input:    "https://gateway.apps.example.com/model-registry/my-registry/api/model_registry/v1alpha3",
-			expected: "https://gateway.apps.example.com:443/model-registry/my-registry",
-		},
-		{
-			name:     "Gateway-based URL with explicit port preserves path prefix",
-			input:    "https://gateway.apps.example.com:443/model-registry/my-registry/api/model_registry/v1alpha3",
-			expected: "https://gateway.apps.example.com:443/model-registry/my-registry",
-		},
-		{
-			name:     "HTTP defaults to port 80",
-			input:    "http://gateway.apps.example.com/model-registry/my-registry/api/model_registry/v1alpha3",
-			expected: "http://gateway.apps.example.com:80/model-registry/my-registry",
-		},
-		{
-			name:     "URL with no path",
-			input:    "https://my-registry-rest.apps.example.com",
-			expected: "https://my-registry-rest.apps.example.com:443",
-		},
-		{
-			name:     "unparseable input returned as-is",
-			input:    "://bad-url",
-			expected: "://bad-url",
-		},
-		{
-			name:     "bare hostname returned as-is",
-			input:    "just-a-hostname",
-			expected: "just-a-hostname",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := registryOriginOnly(tc.input)
-			if got != tc.expected {
-				t.Errorf("registryOriginOnly(%q) = %q, want %q", tc.input, got, tc.expected)
-			}
-		})
-	}
-}
-
 func TestBuildK8sJobMountsTrustedCAForRegistry(t *testing.T) {
 	const (
 		trustedCAConfigMapName            = "job-trusted-ca"

--- a/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
@@ -2,6 +2,9 @@ package repositories
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -18,14 +21,21 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const testNamespace = "test-namespace"
+
 // fakeKubernetesClient is a lightweight test double for KubernetesClientInterface that only
 // implements the methods used by GetAllModelTransferJobs. All other methods either return
 // zero values or panic if unexpectedly called.
 type fakeKubernetesClient struct {
-	jobs              *batchv1.JobList
-	podsByNamespace   map[string]*corev1.PodList
-	jobsByNamespace   map[string]map[string]*batchv1.Job
-	eventsByNamespace map[string]*corev1.EventList
+	jobs                  *batchv1.JobList
+	podsByNamespace       map[string]*corev1.PodList
+	jobsByNamespace       map[string]map[string]*batchv1.Job
+	eventsByNamespace     map[string]*corev1.EventList
+	configMapsByNamespace map[string]map[string]*corev1.ConfigMap
+	secretsByNamespace    map[string]map[string]*corev1.Secret
+	createdConfigMaps     []*corev1.ConfigMap
+	createConfigMapCalls  int
+	failCreateConfigMapAt int
 }
 
 // testContext returns a context with a RequestIdentity set, as required by GetAllModelTransferJobs.
@@ -169,7 +179,15 @@ func (f *fakeKubernetesClient) UpdateCatalogSourceConfig(ctx context.Context, na
 }
 
 func (f *fakeKubernetesClient) CreateSecret(ctx context.Context, namespace string, secret *corev1.Secret) (*corev1.Secret, error) {
-	return nil, nil
+	created := secret.DeepCopy()
+	if created.Name == "" {
+		if created.GenerateName != "" {
+			created.Name = created.GenerateName + "generated"
+		} else {
+			created.Name = "generated-secret"
+		}
+	}
+	return created, nil
 }
 
 func (f *fakeKubernetesClient) PatchSecret(ctx context.Context, namespace string, secretName string, data map[string]string) error {
@@ -181,7 +199,7 @@ func (f *fakeKubernetesClient) DeleteSecret(ctx context.Context, namespace strin
 }
 
 func (f *fakeKubernetesClient) CreateModelTransferJob(ctx context.Context, namespace string, job *batchv1.Job) (*batchv1.Job, error) {
-	return nil, nil
+	return job, nil
 }
 
 func (f *fakeKubernetesClient) GetEventsForPods(ctx context.Context, namespace string, podNames []string) (*corev1.EventList, error) {
@@ -199,7 +217,27 @@ func (f *fakeKubernetesClient) DeleteModelTransferJob(ctx context.Context, names
 }
 
 func (f *fakeKubernetesClient) CreateConfigMap(ctx context.Context, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	return nil, nil
+	f.createConfigMapCalls++
+	if f.failCreateConfigMapAt > 0 && f.createConfigMapCalls == f.failCreateConfigMapAt {
+		return nil, fmt.Errorf("injected create configmap failure")
+	}
+	created := configMap.DeepCopy()
+	if created.Name == "" {
+		if created.GenerateName != "" {
+			created.Name = created.GenerateName + "generated"
+		} else {
+			created.Name = "generated-configmap"
+		}
+	}
+	f.createdConfigMaps = append(f.createdConfigMaps, created)
+	if f.configMapsByNamespace == nil {
+		f.configMapsByNamespace = map[string]map[string]*corev1.ConfigMap{}
+	}
+	if f.configMapsByNamespace[namespace] == nil {
+		f.configMapsByNamespace[namespace] = map[string]*corev1.ConfigMap{}
+	}
+	f.configMapsByNamespace[namespace][created.Name] = created
+	return created, nil
 }
 
 func (f *fakeKubernetesClient) DeleteConfigMap(ctx context.Context, namespace string, name string) error {
@@ -218,11 +256,25 @@ func (f *fakeKubernetesClient) GetModelTransferJob(ctx context.Context, namespac
 }
 
 func (f *fakeKubernetesClient) GetConfigMap(ctx context.Context, namespace string, name string) (*corev1.ConfigMap, error) {
+	if f.configMapsByNamespace != nil {
+		if byNS, ok := f.configMapsByNamespace[namespace]; ok {
+			if configMap, ok := byNS[name]; ok {
+				return configMap, nil
+			}
+		}
+	}
 	return nil, nil
 }
 
 func (f *fakeKubernetesClient) GetSecret(ctx context.Context, namespace string, name string) (*corev1.Secret, error) {
-	return nil, nil
+	if f.secretsByNamespace != nil {
+		if byNS, ok := f.secretsByNamespace[namespace]; ok {
+			if secret, ok := byNS[name]; ok {
+				return secret, nil
+			}
+		}
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "secrets"}, name)
 }
 
 func (f *fakeKubernetesClient) PatchSecretOwnerReference(ctx context.Context, namespace string, name string, ownerRef metav1.OwnerReference) error {
@@ -628,6 +680,448 @@ func TestGetAllModelTransferJobs_NormalRunningJobNotOverridden(t *testing.T) {
 	}
 	if jobModel.ErrorMessage != "" {
 		t.Fatalf("expected no error message for normal running job, got %q", jobModel.ErrorMessage)
+	}
+}
+
+func TestRegistryOriginOnly(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "ClusterIP with explicit port",
+			input:    "http://10.43.0.100:8080/api/model_registry/v1alpha3",
+			expected: "http://10.43.0.100:8080",
+		},
+		{
+			name:     "Route-based HTTPS (no explicit port)",
+			input:    "https://my-registry-rest.apps.example.com/api/model_registry/v1alpha3",
+			expected: "https://my-registry-rest.apps.example.com:443",
+		},
+		{
+			name:     "Route-based HTTPS with explicit port",
+			input:    "https://my-registry-rest.apps.example.com:443/api/model_registry/v1alpha3",
+			expected: "https://my-registry-rest.apps.example.com:443",
+		},
+		{
+			name:     "Gateway-based URL preserves path prefix",
+			input:    "https://gateway.apps.example.com/model-registry/my-registry/api/model_registry/v1alpha3",
+			expected: "https://gateway.apps.example.com:443/model-registry/my-registry",
+		},
+		{
+			name:     "Gateway-based URL with explicit port preserves path prefix",
+			input:    "https://gateway.apps.example.com:443/model-registry/my-registry/api/model_registry/v1alpha3",
+			expected: "https://gateway.apps.example.com:443/model-registry/my-registry",
+		},
+		{
+			name:     "HTTP defaults to port 80",
+			input:    "http://gateway.apps.example.com/model-registry/my-registry/api/model_registry/v1alpha3",
+			expected: "http://gateway.apps.example.com:80/model-registry/my-registry",
+		},
+		{
+			name:     "URL with no path",
+			input:    "https://my-registry-rest.apps.example.com",
+			expected: "https://my-registry-rest.apps.example.com:443",
+		},
+		{
+			name:     "unparseable input returned as-is",
+			input:    "://bad-url",
+			expected: "://bad-url",
+		},
+		{
+			name:     "bare hostname returned as-is",
+			input:    "just-a-hostname",
+			expected: "just-a-hostname",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := registryOriginOnly(tc.input)
+			if got != tc.expected {
+				t.Errorf("registryOriginOnly(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestBuildK8sJobMountsTrustedCAForRegistry(t *testing.T) {
+	const (
+		trustedCAConfigMapName            = "job-trusted-ca"
+		destinationTrustedCAConfigMapName = "destination-trusted-ca"
+	)
+	trustConfig := asyncUploadResolvedTrust{
+		modelRegistryCAMount: &asyncUploadResolvedCAMount{
+			configMapName:       trustedCAConfigMapName,
+			volumeName:          asyncUploadTrustedCAVolumeName,
+			mountPath:           asyncUploadTrustedCAMountPath,
+			fileName:            asyncUploadTrustedCAFileName,
+			annotationConfigKey: asyncUploadTrustedCAConfigAnnot,
+			annotationPathKey:   asyncUploadTrustedCAPathAnnot,
+			envVarName:          "MODEL_SYNC_REGISTRY_CUSTOM_CA",
+		},
+		destinationRegistryCAMount: []asyncUploadResolvedCAMount{{
+			configMapName:       destinationTrustedCAConfigMapName,
+			volumeName:          asyncUploadDestinationTrustedCAVolumeName,
+			mountPath:           asyncUploadDestinationCAPath("quay.io"),
+			fileName:            asyncUploadDestinationCAFileName,
+			annotationConfigKey: asyncUploadDestinationCAConfigAnnot,
+			annotationPathKey:   asyncUploadDestinationCAPathAnnot,
+		}},
+	}
+
+	job := buildK8sJob(
+		"test-job",
+		"job-id",
+		models.ModelTransferJob{
+			Namespace:      "kubeflow",
+			JobDisplayName: "test transfer",
+			UploadIntent:   models.ModelTransferJobUploadIntentUpdateArtifact,
+			Source: models.ModelTransferJobSource{
+				Type: models.ModelTransferJobSourceTypeURI,
+				URI:  "https://example.com/model",
+			},
+			Destination: models.ModelTransferJobDestination{
+				Type:     models.ModelTransferJobDestinationTypeOCI,
+				URI:      "quay.io/example/model:latest",
+				Registry: "quay.io",
+			},
+		},
+		"metadata-config",
+		trustConfig,
+		"",
+		"destination-secret",
+		"https://my-registry-rest.apps.example.com/api/model_registry/v1alpha3",
+		"registry-id",
+		"example.com/async-upload:latest",
+	)
+
+	container := job.Spec.Template.Spec.Containers[0]
+
+	var trustedCAVolume *corev1.Volume
+	for i := range job.Spec.Template.Spec.Volumes {
+		if job.Spec.Template.Spec.Volumes[i].Name == asyncUploadTrustedCAVolumeName {
+			trustedCAVolume = &job.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	if trustedCAVolume == nil {
+		t.Fatalf("expected trusted CA volume %q to be present", asyncUploadTrustedCAVolumeName)
+	}
+	if trustedCAVolume.ConfigMap == nil {
+		t.Fatalf("expected trusted CA volume to use a ConfigMap source")
+	}
+	if trustedCAVolume.ConfigMap.Name != trustedCAConfigMapName {
+		t.Fatalf("expected trusted CA ConfigMap %q, got %q", trustedCAConfigMapName, trustedCAVolume.ConfigMap.Name)
+	}
+	if trustedCAVolume.ConfigMap.Optional == nil || !*trustedCAVolume.ConfigMap.Optional {
+		t.Fatalf("expected trusted CA ConfigMap volume to be optional")
+	}
+
+	var trustedCAMount *corev1.VolumeMount
+	for i := range container.VolumeMounts {
+		if container.VolumeMounts[i].Name == asyncUploadTrustedCAVolumeName {
+			trustedCAMount = &container.VolumeMounts[i]
+			break
+		}
+	}
+	if trustedCAMount == nil {
+		t.Fatalf("expected trusted CA volume mount %q to be present", asyncUploadTrustedCAVolumeName)
+	}
+	if trustedCAMount.MountPath != asyncUploadTrustedCAMountPath {
+		t.Fatalf("expected trusted CA mount path %q, got %q", asyncUploadTrustedCAMountPath, trustedCAMount.MountPath)
+	}
+	if !trustedCAMount.ReadOnly {
+		t.Fatalf("expected trusted CA mount to be read-only")
+	}
+
+	envVars := map[string]string{}
+	for _, envVar := range container.Env {
+		envVars[envVar.Name] = envVar.Value
+	}
+	if envVars["MODEL_SYNC_REGISTRY_CUSTOM_CA"] != asyncUploadTrustedCAFilePath {
+		t.Fatalf("expected MODEL_SYNC_REGISTRY_CUSTOM_CA=%q, got %q", asyncUploadTrustedCAFilePath, envVars["MODEL_SYNC_REGISTRY_CUSTOM_CA"])
+	}
+	if envVars["MODEL_SYNC_REGISTRY_IS_SECURE"] != "true" {
+		t.Fatalf("expected MODEL_SYNC_REGISTRY_IS_SECURE=true, got %q", envVars["MODEL_SYNC_REGISTRY_IS_SECURE"])
+	}
+	if job.Annotations[asyncUploadRegistrySecureAnnot] != "true" {
+		t.Fatalf("expected %s=true, got %q", asyncUploadRegistrySecureAnnot, job.Annotations[asyncUploadRegistrySecureAnnot])
+	}
+	if job.Annotations[asyncUploadTrustedCAConfigAnnot] != trustedCAConfigMapName {
+		t.Fatalf("expected %s=%q, got %q", asyncUploadTrustedCAConfigAnnot, trustedCAConfigMapName, job.Annotations[asyncUploadTrustedCAConfigAnnot])
+	}
+	if job.Annotations[asyncUploadTrustedCAPathAnnot] != asyncUploadTrustedCAFilePath {
+		t.Fatalf("expected %s=%q, got %q", asyncUploadTrustedCAPathAnnot, asyncUploadTrustedCAFilePath, job.Annotations[asyncUploadTrustedCAPathAnnot])
+	}
+	if job.Annotations[asyncUploadDestinationCAConfigAnnot] != destinationTrustedCAConfigMapName {
+		t.Fatalf("expected %s=%q, got %q", asyncUploadDestinationCAConfigAnnot, destinationTrustedCAConfigMapName, job.Annotations[asyncUploadDestinationCAConfigAnnot])
+	}
+
+	var destinationTrustedCAVolume *corev1.Volume
+	for i := range job.Spec.Template.Spec.Volumes {
+		if job.Spec.Template.Spec.Volumes[i].Name == asyncUploadDestinationTrustedCAVolumeName {
+			destinationTrustedCAVolume = &job.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	if destinationTrustedCAVolume == nil {
+		t.Fatalf("expected destination trusted CA volume %q to be present", asyncUploadDestinationTrustedCAVolumeName)
+	}
+	if destinationTrustedCAVolume.ConfigMap == nil {
+		t.Fatalf("expected destination trusted CA volume to use a ConfigMap source")
+	}
+	if destinationTrustedCAVolume.ConfigMap.Name != destinationTrustedCAConfigMapName {
+		t.Fatalf("expected destination trusted CA ConfigMap %q, got %q", destinationTrustedCAConfigMapName, destinationTrustedCAVolume.ConfigMap.Name)
+	}
+
+	var destinationTrustedCAMount *corev1.VolumeMount
+	for i := range container.VolumeMounts {
+		if container.VolumeMounts[i].Name == asyncUploadDestinationTrustedCAVolumeName {
+			destinationTrustedCAMount = &container.VolumeMounts[i]
+			break
+		}
+	}
+	if destinationTrustedCAMount == nil {
+		t.Fatalf("expected destination trusted CA volume mount %q to be present", asyncUploadDestinationTrustedCAVolumeName)
+	}
+	expectedDestinationTrustedCAMountPath := asyncUploadDestinationCAPath("quay.io")
+	if destinationTrustedCAMount.MountPath != expectedDestinationTrustedCAMountPath {
+		t.Fatalf("expected destination trusted CA mount path %q, got %q", expectedDestinationTrustedCAMountPath, destinationTrustedCAMount.MountPath)
+	}
+}
+
+func TestBuildK8sJobSkipsTrustedCAForInsecureRegistry(t *testing.T) {
+	job := buildK8sJob(
+		"test-job-http",
+		"job-id",
+		models.ModelTransferJob{
+			Namespace:      "kubeflow",
+			JobDisplayName: "test transfer",
+			UploadIntent:   models.ModelTransferJobUploadIntentUpdateArtifact,
+			Source: models.ModelTransferJobSource{
+				Type: models.ModelTransferJobSourceTypeURI,
+				URI:  "http://example.com/model",
+			},
+			Destination: models.ModelTransferJobDestination{
+				Type:     models.ModelTransferJobDestinationTypeOCI,
+				URI:      "quay.io/example/model:latest",
+				Registry: "quay.io",
+			},
+		},
+		"metadata-config",
+		asyncUploadResolvedTrust{},
+		"",
+		"destination-secret",
+		"http://my-registry-rest.apps.example.com/api/model_registry/v1alpha3",
+		"registry-id",
+		"example.com/async-upload:latest",
+	)
+
+	container := job.Spec.Template.Spec.Containers[0]
+	for _, volume := range job.Spec.Template.Spec.Volumes {
+		if volume.Name == asyncUploadTrustedCAVolumeName {
+			t.Fatalf("did not expect trusted CA volume for insecure registry")
+		}
+	}
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == asyncUploadTrustedCAVolumeName {
+			t.Fatalf("did not expect trusted CA mount for insecure registry")
+		}
+	}
+
+	envVars := map[string]string{}
+	for _, envVar := range container.Env {
+		envVars[envVar.Name] = envVar.Value
+	}
+	if _, ok := envVars["MODEL_SYNC_REGISTRY_CUSTOM_CA"]; ok {
+		t.Fatalf("did not expect MODEL_SYNC_REGISTRY_CUSTOM_CA for insecure registry")
+	}
+	if envVars["MODEL_SYNC_REGISTRY_IS_SECURE"] != "false" {
+		t.Fatalf("expected MODEL_SYNC_REGISTRY_IS_SECURE=false, got %q", envVars["MODEL_SYNC_REGISTRY_IS_SECURE"])
+	}
+	if job.Annotations[asyncUploadRegistrySecureAnnot] != "false" {
+		t.Fatalf("expected %s=false, got %q", asyncUploadRegistrySecureAnnot, job.Annotations[asyncUploadRegistrySecureAnnot])
+	}
+	if _, ok := job.Annotations[asyncUploadTrustedCAConfigAnnot]; ok {
+		t.Fatalf("did not expect %s annotation for insecure registry", asyncUploadTrustedCAConfigAnnot)
+	}
+	if _, ok := job.Annotations[asyncUploadTrustedCAPathAnnot]; ok {
+		t.Fatalf("did not expect %s annotation for insecure registry", asyncUploadTrustedCAPathAnnot)
+	}
+	if _, ok := job.Annotations[asyncUploadDestinationCAConfigAnnot]; ok {
+		t.Fatalf("did not expect %s annotation for insecure registry", asyncUploadDestinationCAConfigAnnot)
+	}
+}
+
+func TestResolveAsyncUploadModelRegistryTrustCreatesGeneratedBundleFromBundlePaths(t *testing.T) {
+	bundleFile := filepath.Join(t.TempDir(), "ca-bundle.crt")
+	if err := os.WriteFile(bundleFile, []byte("bundle-paths-pem"), 0o600); err != nil {
+		t.Fatalf("failed to write bundle file: %v", err)
+	}
+	client := &fakeKubernetesClient{}
+
+	trustMount, managedConfigMaps, err := resolveAsyncUploadModelRegistryTrust(
+		testContext(),
+		client,
+		testNamespace,
+		"job-id",
+		true,
+		[]string{bundleFile},
+	)
+	if err != nil {
+		t.Fatalf("resolveAsyncUploadModelRegistryTrust returned error: %v", err)
+	}
+	if trustMount == nil {
+		t.Fatalf("expected model registry trust mount")
+	}
+	if trustMount.configMapName == "" || trustMount.configMapName == asyncUploadTrustedCAConfigMapName {
+		t.Fatalf("expected a generated trusted CA configmap name, got %q", trustMount.configMapName)
+	}
+	if len(managedConfigMaps) != 1 || managedConfigMaps[0] != trustMount.configMapName {
+		t.Fatalf("expected managed configmaps to contain %q, got %#v", trustMount.configMapName, managedConfigMaps)
+	}
+	if len(client.createdConfigMaps) != 1 {
+		t.Fatalf("expected 1 created configmap, got %d", len(client.createdConfigMaps))
+	}
+	createdConfigMap := client.createdConfigMaps[0]
+	if createdConfigMap.Namespace != testNamespace {
+		t.Fatalf("expected created configmap namespace %q, got %q", testNamespace, createdConfigMap.Namespace)
+	}
+	if createdConfigMap.Data[asyncUploadTrustedCAFileName] != "bundle-paths-pem" {
+		t.Fatalf(
+			"expected trusted CA data %q, got %q",
+			"bundle-paths-pem",
+			createdConfigMap.Data[asyncUploadTrustedCAFileName],
+		)
+	}
+}
+
+func TestResolveAsyncUploadModelRegistryTrustFallsBackWhenBundlePathsUnavailable(t *testing.T) {
+	client := &fakeKubernetesClient{}
+
+	trustMount, managedConfigMaps, err := resolveAsyncUploadModelRegistryTrust(
+		testContext(),
+		client,
+		testNamespace,
+		"job-id",
+		true,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("resolveAsyncUploadModelRegistryTrust returned error: %v", err)
+	}
+	if trustMount == nil {
+		t.Fatalf("expected fallback model registry trust mount")
+	}
+	if trustMount.configMapName != asyncUploadTrustedCAConfigMapName {
+		t.Fatalf("expected fallback trusted CA configmap %q, got %q", asyncUploadTrustedCAConfigMapName, trustMount.configMapName)
+	}
+	if len(managedConfigMaps) != 0 {
+		t.Fatalf("expected no managed configmaps, got %#v", managedConfigMaps)
+	}
+}
+
+func TestResolveAsyncUploadDestinationRegistryTrustCreatesGeneratedServiceBundle(t *testing.T) {
+	client := &fakeKubernetesClient{
+		configMapsByNamespace: map[string]map[string]*corev1.ConfigMap{
+			testNamespace: {
+				asyncUploadOpenShiftServiceCAConfigMap: {
+					Data: map[string]string{
+						asyncUploadOpenShiftServiceCAConfigMapKey: "service-ca-pem",
+					},
+				},
+			},
+		},
+	}
+
+	trustMounts, managedConfigMaps, err := resolveAsyncUploadDestinationRegistryTrust(
+		testContext(),
+		client,
+		testNamespace,
+		"job-id",
+		"image-registry.openshift-image-registry.svc:5000",
+	)
+	if err != nil {
+		t.Fatalf("resolveAsyncUploadDestinationRegistryTrust returned error: %v", err)
+	}
+	if len(trustMounts) != 1 {
+		t.Fatalf("expected 1 destination trust mount, got %d", len(trustMounts))
+	}
+	if len(managedConfigMaps) != 1 || managedConfigMaps[0] != trustMounts[0].configMapName {
+		t.Fatalf("expected managed configmaps to contain %q, got %#v", trustMounts[0].configMapName, managedConfigMaps)
+	}
+	if len(client.createdConfigMaps) != 1 {
+		t.Fatalf("expected 1 created configmap, got %d", len(client.createdConfigMaps))
+	}
+	createdConfigMap := client.createdConfigMaps[0]
+	if createdConfigMap.Data[asyncUploadDestinationCAFileName] != "service-ca-pem" {
+		t.Fatalf(
+			"expected destination trusted CA data %q, got %q",
+			"service-ca-pem",
+			createdConfigMap.Data[asyncUploadDestinationCAFileName],
+		)
+	}
+}
+
+func TestResolveAsyncUploadDestinationRegistryTrustSkipsNonClusterServiceRegistry(t *testing.T) {
+	client := &fakeKubernetesClient{}
+
+	trustMounts, managedConfigMaps, err := resolveAsyncUploadDestinationRegistryTrust(
+		testContext(),
+		client,
+		testNamespace,
+		"job-id",
+		"registry.example.com:5000",
+	)
+	if err != nil {
+		t.Fatalf("resolveAsyncUploadDestinationRegistryTrust returned error: %v", err)
+	}
+	if len(trustMounts) != 0 {
+		t.Fatalf("did not expect destination trust mounts for non-cluster service registry")
+	}
+	if len(managedConfigMaps) != 0 {
+		t.Fatalf("expected no managed configmaps, got %#v", managedConfigMaps)
+	}
+}
+
+func TestResolveAsyncUploadTrustReturnsPartialStateOnDestinationTrustError(t *testing.T) {
+	bundleFile := filepath.Join(t.TempDir(), "ca-bundle.crt")
+	if err := os.WriteFile(bundleFile, []byte("bundle-paths-pem"), 0o600); err != nil {
+		t.Fatalf("failed to write bundle file: %v", err)
+	}
+	client := &fakeKubernetesClient{
+		configMapsByNamespace: map[string]map[string]*corev1.ConfigMap{
+			testNamespace: {
+				asyncUploadOpenShiftServiceCAConfigMap: {
+					Data: map[string]string{
+						asyncUploadOpenShiftServiceCAConfigMapKey: "service-ca-pem",
+					},
+				},
+			},
+		},
+		failCreateConfigMapAt: 2,
+	}
+
+	trustConfig, err := resolveAsyncUploadTrust(
+		testContext(),
+		client,
+		testNamespace,
+		"job-id",
+		true,
+		"https://example.apps.test/api/model_registry/v1alpha3",
+		"image-registry.openshift-image-registry.svc:5000",
+		[]string{bundleFile},
+	)
+	if err == nil {
+		t.Fatalf("expected resolveAsyncUploadTrust to return an error")
+	}
+	if trustConfig.modelRegistryCAMount == nil {
+		t.Fatalf("expected partial trust config to retain model registry trust mount")
+	}
+	if len(trustConfig.managedConfigMaps) != 1 {
+		t.Fatalf("expected 1 managed configmap before destination failure, got %d", len(trustConfig.managedConfigMaps))
 	}
 }
 

--- a/jobs/async-upload/job/config.py
+++ b/jobs/async-upload/job/config.py
@@ -514,6 +514,18 @@ def get_config(argv: list[str] | None = None) -> AsyncUploadConfig:
             logger.error("❌ Failed to load ConfigMap metadata: %s", e)
             raise
 
+    registry_custom_ca = args.registry_custom_ca
+    if registry_custom_ca is not None:
+        custom_ca_path = Path(registry_custom_ca).expanduser()
+        if custom_ca_path.exists():
+            registry_custom_ca = str(custom_ca_path)
+        else:
+            logger.info(
+                "Registry custom CA file %s not found, falling back to system defaults",
+                custom_ca_path,
+            )
+            registry_custom_ca = None
+
     intent_type = model_args.intent_type
     if intent_type in (UploadIntent.create_model, UploadIntent.create_version):
         if metadata is None:
@@ -544,7 +556,7 @@ def get_config(argv: list[str] | None = None) -> AsyncUploadConfig:
                 author=args.registry_author,
                 user_token=args.registry_user_token,
                 user_token_envvar=args.registry_user_token_envvar,
-                custom_ca=args.registry_custom_ca,
+                custom_ca=registry_custom_ca,
                 custom_ca_envvar=args.registry_custom_ca_envvar,
                 log_level=args.registry_log_level,
             ),

--- a/jobs/async-upload/tests/test_config.py
+++ b/jobs/async-upload/tests/test_config.py
@@ -511,3 +511,28 @@ def test_oci_credentials_file_loading(
     assert config.destination.email == expected["email"]
 
 
+def test_registry_custom_ca_uses_existing_file(
+    update_artifact_intent_env_vars, source_s3_env_vars, destination_oci_env_vars, tmp_path
+):
+    custom_ca = tmp_path / "ca-bundle.crt"
+    custom_ca.write_text("test ca bundle")
+
+    config = get_config([
+        "--registry-custom-ca", str(custom_ca),
+    ])
+
+    assert config.registry.custom_ca == str(custom_ca)
+
+
+def test_registry_custom_ca_missing_file_falls_back_to_system_defaults(
+    update_artifact_intent_env_vars, source_s3_env_vars, destination_oci_env_vars, tmp_path
+):
+    missing_custom_ca = tmp_path / "missing-ca-bundle.crt"
+
+    config = get_config([
+        "--registry-custom-ca", str(missing_custom_ca),
+    ])
+
+    assert config.registry.custom_ca is None
+
+


### PR DESCRIPTION
## Summary
- Cherry-pick [kubeflow/hub#3064](https://github.com/kubeflow/hub/pull/3064) (`75219019`) onto `rhoai-3.4`
- Mount trusted CA bundles into secure async transfer jobs so model registry callbacks and well-known in-cluster OCI pushes succeed on clusters with private/self-signed trust roots
- Preserve fallback when optional CA files are absent; isolate platform-specific trust resolution behind the BFF resolver

## Notes
- One conflict resolved in `clients/ui/bff/internal/repositories/model_transfer_jobs_test.go` (kept incoming trust-related tests ahead of existing `resolveAsyncUploadImage` suite)

## Test plan
- [ ] `go test ./internal/repositories -run '^(TestBuildK8sJob|TestResolveAsyncUpload)'` in `clients/ui/bff`
- [ ] Confirm transfer jobs mount MR CA at `/etc/pki/tls/custom/ca-bundle.crt` when present
- [ ] Confirm destination registry CA mounts under `/etc/containers/certs.d/<host>/ca.crt` when present
- [ ] Confirm `MODEL_SYNC_REGISTRY_CUSTOM_CA` is set on the job pod when applicable
- [ ] Validate async transfer against a federated MR route / internal registry on a self-signed-cert cluster

Assisted-by: Cursor Grok 4.5

Made with [Cursor](https://cursor.com)

reference: https://redhat.atlassian.net/browse/RHOAIENG-82406