### PR TITLE
fix: use pull_request_target in gatekeeper workflow

### DIFF
--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -1,0 +1,12 @@
+name: Post-Codefreeze Gatekeeper
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, labeled]
+    branches:
+      - 'rhoai-3.5'
+jobs:
+  post-codefreeze-gate:
+    if: github.event.action != 'labeled' || github.event.label.name == 'run-gatekeeper'
+    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@main
+    secrets: inherit


### PR DESCRIPTION
Updates the gatekeeper workflow to use `pull_request_target` instead of `pull_request` and points to `@main`.

Jira: [RHOAIENG-82825](https://redhat.atlassian.net/browse/RHOAIENG-82825)